### PR TITLE
Bug fix: ensure creation of dataHierarchy field

### DIFF
--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -341,7 +341,7 @@ def podds2resource:
     if .theme then . else del(.theme) end |
     if .issued then . else del(.issued) end |
     if .components then .inventory = (.components | inventory_components) else . end |
-#    if .components and ((.components|map(select(.filepath))|length) > 0) then .dataHierarchy = (.components|hierarchy("")) else . end |
+    if .components and ((.components|map(select(.filepath))|length) > 0) then .dataHierarchy = (.components|hierarchy("")) else . end |
     if .["@id"] then .["@context"] = [ .["@context"], { "@base": .["@id"] }] else . end 
 ;
 

--- a/jq/tests/test_podds2resource.py
+++ b/jq/tests/test_podds2resource.py
@@ -65,7 +65,7 @@ class TestJanaf(unittest.TestCase):  #
         self.assertLessEqual(len(comps), 318,
                    "Extra components; have {0}/{1}".format(len(comps), 318))
 
-        props = "title describedBy downloadURL mediaType".split()
+        props = "title describedBy downloadURL mediaType filepath".split()
         for prop in props:
             self.assertIn(prop, comps[0], "Property not found: " + prop)
             self.assertIsInstance(comps[0][prop], types.StringTypes,
@@ -98,6 +98,14 @@ class TestJanaf(unittest.TestCase):  #
         exts = refs[0]['_extensionSchemas']
         self.assertEquals(len(exts), 1)
         self.assertIn(nerdm+"/definitions/DCiteDocumentReference", exts)
+
+    def test_hierarchy(self):
+        self.assertIn("dataHierarchy", self.out,
+                      "record is missing 'dataHierarchy' field")
+        hier = self.out['dataHierarchy']
+        self.assertEqual(len(hier), 318)
+        self.assertIn('filepath', hier[0])
+        self.assertIn('filepath', hier[-1])
         
 
 class TestValidateNerdm(unittest.TestCase):


### PR DESCRIPTION
For reasons forgotten, the line in the converter that creates the NERDm `dataHierarchy` field was commented out.  This PR uncomments the line to ensure its creation.  I also added a test to check that the field gets created.  
@deoyani 