### PR TITLE
ingest: fix validation errors 

### DIFF
--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -68,7 +68,7 @@ def cvtref:  {
 def componentID(prefix):
     prefix + 
     (if .filepath then .filepath else
-        if .accessURL then (.accessURL | urlpath) else
+        if .accessURL then (.accessURL | urlpath | sub("^/doi:"; "/")) else
            if .downloadURL then (.downloadURL | urlpath) else
                null
            end
@@ -179,7 +179,7 @@ def dist2comp:
 #
 def doiFromDist:
     (map(select(.accessURL)| .accessURL | scan("https?://.*doi\\.org/.*")) | .[0]) as $auri |
-    if $auri then ($auri | sub("https?://.*doi.org/"; "doi:")) else null end
+    if $auri then ($auri | sub("https?://.*doi.org/(doi:)?"; "doi:")) else null end
 ;
 
 # return a unique list of the @type values from all objects in an array

--- a/scripts/ingest-nerdm-res.py
+++ b/scripts/ingest-nerdm-res.py
@@ -125,7 +125,7 @@ def load_from_file(filepath, loader, validate=True):
 
 def fmterrs(errs):
     msgs = str(errs[0]).split("\n")
-    out = msge[0]
+    out = msgs[0]
     if len(errs) > 1 or len(msgs) > 1:
         out += "..."
     return out

--- a/scripts/ingest-nerdm-res.py
+++ b/scripts/ingest-nerdm-res.py
@@ -101,7 +101,8 @@ def main(args):
                       .format(parser.prog), file=sys.stderr)
                 for f in res.failures():
                     why = (isinstance(f.errs[0], RecordIngestError) and \
-                               str(f.errs)) or "Validation errors"
+                               "Ingest error") or "Validation errors"
+                    why += ": "+str( [str(e) for e in f.errs] )
                     print("\t{0}: \t{1}".format(str(f.key), why))
             else:
                 print("{0}: {1}: {2} out of {3} records failed to load"

--- a/scripts/ingest-nerdm-res.py
+++ b/scripts/ingest-nerdm-res.py
@@ -113,7 +113,7 @@ def main(args):
                                                        totres.attempt_count))
 
     if totres.failure_count > 0:
-        stat = 1
+        stat = 2
     return stat
 
 def load_from_dir(dirpath, loader, validate=True):

--- a/scripts/ingest-nerdm-res.py
+++ b/scripts/ingest-nerdm-res.py
@@ -102,7 +102,7 @@ def main(args):
                 for f in res.failures():
                     why = (isinstance(f.errs[0], RecordIngestError) and \
                                "Ingest error") or "Validation errors"
-                    why += ": "+str( [str(e) for e in f.errs] )
+                    why += ": "+fmterrs(f.errs)
                     print("\t{0}: \t{1}".format(str(f.key), why))
             else:
                 print("{0}: {1}: {2} out of {3} records failed to load"
@@ -123,6 +123,13 @@ def load_from_dir(dirpath, loader, validate=True):
 def load_from_file(filepath, loader, validate=True):
     return loader.load_from_file(filepath, validate)
 
+def fmterrs(errs):
+    msgs = str(errs[0]).split("\n")
+    out = msge[0]
+    if len(errs) > 1 or len(msgs) > 1:
+        out += "..."
+    return out
+    
     
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
An updated version of the NIST PDL catalog included some records that were failing validation during ingest.  This was due to an anomalous version of the DOI URL, albeit one that still resolves properly.  I updated the nerdm translator to accept this form.  

The ingest script also has some minor changes that allows validation errors to be more easily detected and reacted to.  

A related change was made to oar-docker to ensure that validation errors not prevent the creating of the database index.  