### PR TITLE
localdeploy/AWSCodeDeploy support

### DIFF
--- a/scripts/install_extras.sh
+++ b/scripts/install_extras.sh
@@ -25,8 +25,9 @@ echo
 
 # install the merge configurations
 mkdir -p $MERGE_ETCDIR
+merge_etcpath=`(cd $MERGE_ETCDIR && pwd)`
 echo tar cf - merge \| \(cd $MERGE_ETCDIR/.. \&\& tar xf -\)
-(cd $SOURCE_DIR/etc && (tar cf - --exclude-backups --exclude=README\* merge | (cd $MERGE_ETCDIR/.. && tar xf -)))
+(cd $SOURCE_DIR/etc && (tar cf - --exclude-backups --exclude=README\* merge | (cd $merge_etcpath/.. && tar xf -)))
 echo
 
 #install extra scripts

--- a/scripts/makedist.sh
+++ b/scripts/makedist.sh
@@ -1,0 +1,49 @@
+#! /bin/bash
+#
+# This script creates a distribution bundle for installing into the OAR system
+# via oar-docker
+#
+set -e
+prog=`basename $0`
+execdir=`dirname $0`
+[ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
+base=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
+
+true ${SOURCE_DIR:=$base}
+
+# handle command line options
+while [ "$1" != "" ]; do 
+  case "$1" in
+    --dist-dir=*)
+        DIST_DIR=`echo $1 | sed -e 's/[^=]*=//'`
+        ;;
+    --dist-dir)
+        shift
+        DIST_DIR=$1
+        ;;
+    --source-dir=*|--dir=*)
+        SOURCE_DIR=`echo $1 | sed -e 's/[^=]*=//'`
+        ;;
+    -d|--dir|--source-dir)
+        shift
+        SOURCE_DIR=$1
+        ;;
+    -*)
+        echo "$prog: unsupported option:" $1
+        false
+        ;;
+    *)
+        echo "Warning: ignoring argument: $1"
+        ;;
+  esac
+  shift
+done
+
+true ${DIST_DIR:=$SOURCE_DIR/dist}
+
+installdir=$DIST_DIR/pdr/nerdm
+set -x
+mkdir -p $installdir
+scripts/install.sh --install-dir=$installdir
+
+(cd $DIST_DIR && zip -qr pdr-nerdm.zip pdr)


### PR DESCRIPTION
This PR allows provides changes that allow the package to be built and deployed via AWSCodeDeploy and oar-docker's localdeploy tool.  In particular, it allows installation into a directory relative to the package.  It also adds a script for creating a distinction distribution bundle for deployment into a system.  