### PR TITLE
initial scripts to support AWS CodeDeploy

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,15 @@
+version: 0.0
+
+os: linux
+# 1) Copy all the build files to the sdp html folder
+files:
+  - source:  dist/pdr-nerdm.zip
+    destination: /home/ubuntu/oar-docker/apps/rmm/ingest
+    
+hooks:
+ BeforeInstall:
+   - location:  scripts/beforecicd.sh
+     runas: root
+ AfterInstall:
+   - location:  scripts/aftercicd.sh
+     runas: root

--- a/scripts/aftercicd.sh
+++ b/scripts/aftercicd.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+APP_DIR=/home/ubuntu/oar-docker/apps
+DOCKER_CONTAINER_NAME=rmm-ingest
+cd $APP_DIR
+
+if [[ $(sudo docker ps -aqf "name=$DOCKER_CONTAINER_NAME") ]]; then
+    sudo docker rm -f $(sudo docker ps -aqf "name=$DOCKER_CONTAINER_NAME")
+fi
+if [[ $(sudo docker images $DOCKER_CONTAINER_NAME -aq) ]]; then
+   sudo docker rmi -f $(sudo docker images $DOCKER_CONTAINER_NAME -aq)
+fi
+
+sudo docker-compose rm -f
+[ -e "${APP_DIR}/rmm/mongod/db" ] && sudo rm -rf ${APP_DIR}/rmm/mongod/db
+sudo docker-compose build --no-cache
+sudo docker-compose up -d
+

--- a/scripts/beforecicd.sh
+++ b/scripts/beforecicd.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+sudo rm -r /opt/data/backup/oar-metadata/*
+if [ -f /home/ubuntu/oar-docker/rmm/ingest/pdr-nerdm.zip ];
+then
+  #backup previous build
+  sudo cp -r /home/ubuntu/oar-docker/rmm/ingest/pdr-nerdm.zip /opt/data/backup/oar-metadata
+  #remove previous build
+  sudo rm -r /home/ubuntu/oar-docker/rmm/ingest/pdr-nerdm.zip
+fi


### PR DESCRIPTION
Code from oar-metadata is used in the ingest container (i.e. [oar-docker](https://github.com/usnistgov/oar-docker):apps/rmm/ingest).  Currently, this code is built as part of the nerdm Dockerfile; for compliance with our test and deploy procedures, the nerdm container is replace with building via Jenkins and CodeDeploy.