### PR TITLE
Fix/446 datahier: added helper function for generating `dataHierarchy` for use in python

### DIFF
--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -292,11 +292,10 @@ def inventory_components:
 def hierarchy(within):
     select_comp_within(within) | map(select(.filepath)) | . as $desc | 
     select_comp_children(within) |
-    map( { filepath, downloadURL, type: .["@type"], } | .filepath as $fp |
+    map( { filepath, type: .["@type"], } | .filepath as $fp |
          if .type and (.type|contains(["Subcollection"])) then
              .children = ($desc | hierarchy($fp))
          else . end |
-         if .downloadURL then . else del(.downloadURL) end |
          del(.type)
     )  
 ;

--- a/jq/tests/test_pod2nerdm.jqt
+++ b/jq/tests/test_pod2nerdm.jqt
@@ -268,26 +268,26 @@ include "pod2nerdm"; .inventory = (.components | inventory_components)
 # hierarchy -- flat top level collection
 include "pod2nerdm"; hierarchy("")
 [ {"filepath": "A", "@type": [ "DataFile" ], "downloadURL": "/dev/null"}, {"filepath": "B" } ]
-[ {"filepath": "A", "downloadURL": "/dev/null" },{ "filepath": "B" }]
+[ {"filepath": "A" },{ "filepath": "B" }]
 
 # hierarchy -- 2 levels
 include "pod2nerdm"; hierarchy("")
 [ {"filepath": "A", "@type": [ "DataFile" ], "downloadURL": "/dev/null"}, {"filepath": "B", "@type": [ "Subcollection" ] } ]
-[ {"filepath": "A", "downloadURL": "/dev/null" },{ "filepath": "B", "children": [] }]
+[ {"filepath": "A" },{ "filepath": "B", "children": [] }]
 
 # hierarchy -- 3 levels
 include "pod2nerdm"; hierarchy("")
 [ {"filepath": "A", "@type": [ "DataFile" ], "downloadURL": "/dev/null"}, {"filepath": "B", "@type": [ "Subcollection" ] }, { "filepath": "B/C", "@type": ["Fool"] } ]
-[ {"filepath": "A", "downloadURL": "/dev/null" },{ "filepath": "B", "children": [ { "filepath": "B/C" }] }]
+[ {"filepath": "A" },{ "filepath": "B", "children": [ { "filepath": "B/C" }] }]
 
 # hierarchy -- 3 levels with non-data component
 include "pod2nerdm"; hierarchy("")
 [ {"filepath": "A", "@type": [ "DataFile" ], "downloadURL": "/dev/null"}, {"@type": [ "AccessPage" ]}, {"filepath": "B", "@type": [ "Subcollection" ] }, { "filepath": "B/C", "@type": ["Fool"] } ]
-[ {"filepath": "A", "downloadURL": "/dev/null" },{ "filepath": "B", "children": [ { "filepath": "B/C" }] }]
+[ {"filepath": "A" },{ "filepath": "B", "children": [ { "filepath": "B/C" }] }]
 
 include "pod2nerdm"; hierarchy("")
 [ {"filepath": "A", "@type": [ "DataFile" ], "downloadURL": "/dev/null"}, {"filepath": "B", "@type": [ "Subcollection" ] }, { "filepath": "B/C", "@type": ["Fool"] },  {"filepath": "B/D", "@type": [ "Subcollection" ] }, {"filepath": "B/D/A", "@type": [ "DataFile" ], "downloadURL": "/dev/null"}]
-[ {"filepath": "A", "downloadURL": "/dev/null" },{ "filepath": "B", "children": [ { "filepath": "B/C" }, {"filepath": "B/D", "children": [ {"filepath": "B/D/A", "downloadURL": "/dev/null" }]}]}]
+[ {"filepath": "A" },{ "filepath": "B", "children": [ { "filepath": "B/C" }, {"filepath": "B/D", "children": [ {"filepath": "B/D/A" }]}]}]
 
 
 # testing podds2resoure:

--- a/python/nistoar/jq.py
+++ b/python/nistoar/jq.py
@@ -138,7 +138,7 @@ class Jq(object):
         create the Jq filter machine.  
 
         :param jqfilter str:   the jq filter to apply to the input data; module
-                               import statements can be left by using the 
+                               import statements can be left out by using the 
                                modules argument.
         :param libpath str:    the path to the directory containing needed 
                                jq module files

--- a/python/nistoar/nerdm/convert.py
+++ b/python/nistoar/nerdm/convert.py
@@ -51,7 +51,7 @@ class PODds2Res(object):
 
 class ComponentCounter(object):
     """
-    a class for calculating inventories using conversion macros
+    a class for calculating inventories using the jq conversion macros
     """
 
     def __init__(self, jqlibdir):
@@ -104,3 +104,38 @@ class ComponentCounter(object):
         jqt = self._make_jqt(macro)
         datastr = json.dumps(components)
         return jqt.transform(datastr)
+
+class HierarchyBuilder(object):
+    """
+    a class for calculating data hierarchies using the jq conversion macros
+    """
+
+    def __init__(self, jqlibdir):
+        """
+        create the builder.
+
+        :param jqlibdir str:   path to the directory containing the nerdm jq
+                               modules
+        """
+        self._modules = ["pod2nerdm:nerdm"]
+        self._jqlibdir = jqlibdir
+
+        self._hier_jqt = self._make_jqt('nerdm::hierarchy("")')
+                              
+    def _make_jqt(self, macro):
+        return jq.Jq(macro, self._jqlibdir, self._modules)
+
+    def build_hierarchy(self, components):
+        """
+        return an array representing the data hierarchy for a given set of 
+        components.
+
+        This is implemented via the appropriate jq translation macros.  
+        """
+        datastr = json.dumps(components)
+        return self._hier_jqt.transform(datastr)
+
+
+        
+    
+    

--- a/python/nistoar/nerdm/tests/test_convert.py
+++ b/python/nistoar/nerdm/tests/test_convert.py
@@ -91,6 +91,23 @@ fullinv = [
     "childCollections": [ "trial3" ]
 }, trial3inv ]
 
+simplehier = [
+    {
+        "filepath": "trial1.json"
+    },
+    {
+        "filepath": "trial2.json"
+    },
+    {
+        "filepath": "trial3",
+        "children": [
+            {
+                "filepath": "trial3/trial3a.json"
+            }
+        ]
+    }
+]
+
 class TestComponentCounter(unittest.TestCase):
 
     def test_inventory_collection(self):
@@ -107,7 +124,13 @@ class TestComponentCounter(unittest.TestCase):
         cc = cvt.ComponentCounter(jqlibdir)
         inv = cc.inventory(simplenerd['components'])
         self.assertEqual(inv, fullinv)
-        
+
+class TestHierarchyBuilder(unittest.TestCase):
+
+    def test_build_hierarchy(self):
+        hb = cvt.HierarchyBuilder(jqlibdir)
+        hier = hb.build_hierarchy(simplenerd['components'])
+        self.assertEquals(hier, simplehier)
         
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR partially addresses [ODD-446 ("mdserver: all files not appearing in dataHierarchy property")](http://mml.nist.gov:8080/browse/ODD-446) by providing a helper function callable from python that generates the `dataHierarchy` node for a NERDm record.  It wraps around the corresponding **jq** conversion macro.  

Since this PR does not provide full fix for [ODD-446](http://mml.nist.gov:8080/browse/ODD-446), I think that it would be sufficient to just to note if the Travis CI tests passed (i.e. should say "All checks have passed" below); if so, you can merge. 