### PR TITLE
support access key via request header

### DIFF
--- a/python/nistoar/rmm/ingest/wsgi.py
+++ b/python/nistoar/rmm/ingest/wsgi.py
@@ -57,8 +57,13 @@ class RMMRecordIngestApp(object):
         self._loaders = {}
         self._loaders['nerdm'] = NERDmLoader(self.dburl, self.schemadir,
                                              onupdate='quiet')
+
+        authkey = config.get('auth_key')
+        authmeth= config.get('auth_method')
+        if authmeth != 'header':
+            authmeth = 'qparam'
+        self._auth = (authmeth, authkey)
         
-        self._auth = config.get('auth_key')
 
     def handle_request(self, env, start_resp):
         handler = Handler(self._loaders, env, start_resp, self._auth)
@@ -71,14 +76,14 @@ app = RMMRecordIngestApp
 
 class Handler(object):
 
-    def __init__(self, loaders, wsgienv, start_resp, authkey=None):
+    def __init__(self, loaders, wsgienv, start_resp, auth=None):
         self._env = wsgienv
         self._start = start_resp
         self._meth = wsgienv.get('REQUEST_METHOD', 'GET')
         self._hdr = Headers([])
         self._code = 0
         self._msg = "unknown status"
-        self._auth = authkey
+        self._auth = auth
 
         self._loaders = loaders
 
@@ -102,9 +107,8 @@ class Handler(object):
         meth_handler = 'do_'+self._meth
 
         path = self._env.get('PATH_INFO', '/')[1:]
-        params = cgi.parse_qs(self._env.get('QUERY_STRING', ''))
-        if not self.authorize(params.get('auth',[])):
-            return self.send_error(401, "Not authorized")
+        if not self.authorize():
+            return self.send_unauthorized()
 
         if hasattr(self, meth_handler):
             return getattr(self, meth_handler)(path)
@@ -112,13 +116,39 @@ class Handler(object):
             return self.send_error(403, self._meth +
                                    " not supported on this resource")
 
-    def authorize(self, auths):
-        if self._auth:
+    def authorize(self):
+        if self._auth[0] == 'header':
+            return self.authorize_via_headertoken()
+        else:
+            return self.authorize_via_queryparam()
+
+    def authorize_via_queryparam(self):
+        params = cgi.parse_qs(self._env.get('QUERY_STRING', ''))
+        auths = params.get('auth',[])
+        if self._auth[1]:
             # match the last value provided
-            return len(auths) > 0 and self._auth == auths[-1]  
+            return len(auths) > 0 and self._auth[1] == auths[-1]  
         if len(auths) > 0:
             log.warn("Authorization key provided, but none has been configured")
         return len(auths) == 0
+
+    def authorize_via_headertoken(self):
+        authhdr = self._env.get('HTTP_AUTHORIZATION', "")
+        log.debug("Request HTTP_AUTHORIZATION: %s", authhdr)
+        parts = authhdr.split()
+        if self._auth[1]:
+            return len(parts) > 1 and parts[0] == "Bearer" and \
+                self._auth[1] == parts[1]
+        if authhdr:
+            log.warn("Authorization key provided, but none has been configured")
+        return authhdr == ""
+
+    def send_unauthorized(self):
+        self.set_response(401, "Not authorized")
+        if self._auth[0] == 'header':
+            self.add_header('WWW-Authenticate', 'Bearer')
+        self.end_headers()
+        return []
 
     def do_GET(self, path):
         path = path.strip('/')


### PR DESCRIPTION
This PR implements the recommendation described in [ODD-513](http://mml.nist.gov:8080/browse/ODD-513).  Via a configuration parameter("auth_method", at the same position as "auth_key"), the ingest service can be set to accept the authorization key via the HTTP header, Authorization (specifying the "Bearer" scheme).  This repo contains the server support; client support can be found in oar-pdr.  