### PR TITLE
 Preservation and ingest update, bug fixes

### DIFF
--- a/docker/ejsonschema/Dockerfile
+++ b/docker/ejsonschema/Dockerfile
@@ -2,14 +2,9 @@ FROM oarmeta/jq:latest
 
 RUN apt-get update && apt-get install -y python python-pip python-dev unzip \
                                          uwsgi uwsgi-plugin-python python-yaml
-RUN pip install json-spec jsonschema requests pynoid filelock
+RUN pip install json-spec jsonmerge==1.3.0 jsonschema requests pynoid pytest filelock 
 
 WORKDIR /root
-RUN curl -L -o jsonmerge.zip \
-    https://github.com/RayPlante/jsonmerge/archive/oar.zip && \
-    unzip jsonmerge.zip && \
-    cd jsonmerge-oar && \
-    python setup.py install
 
 RUN curl -L -o ejsonschema.zip \
     https://github.com/usnistgov/ejsonschema/archive/master.zip && \

--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -46,6 +46,34 @@ def urlpath:
     sub("^\\w+:(//\\w+\\.\\w+(\\.\\w+)*(:\\d+)?)?"; "")
 ;
 
+# trim whitespace from the beginning of a string
+#
+# Input: string
+# Output: string
+#
+def ltrimsp:
+    sub("^\\s+"; "")
+;
+
+# trim whitespace from the end of a string
+#
+# Input: string
+# Output: string
+#
+def rtrimsp:
+    sub("\\s+$"; "")
+;
+
+# trim whitespace from both ends of a string
+#
+# Input: string
+# Output: string
+#
+def trimsp:
+    ltrimsp | rtrimsp
+;
+
+
 # given a string that looks like a file path, return the path to the
 # file's parent directory
 #
@@ -416,7 +444,7 @@ def podds2resource:
         ediid: .identifier,
         landingPage,
         
-        description:  .description | split("\n\n"),
+        description:  .description | split("\n\n") | map(trimsp),
         keyword,
         theme,
         topic: [],

--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -160,7 +160,11 @@ def filepath:
           if test("https?://data.nist.gov/od/ds/\\w+/") then
              sub("https?://data.nist.gov/od/ds/\\w+/"; "")
           else
-             sub(".*/"; "")
+            if test("https?://testdata.nist.gov/od/ds/\\w+/") then
+               sub("https?://testdata.nist.gov/od/ds/\\w+/"; "")
+            else
+               sub(".*/"; "")
+            end
           end
         end
       end

--- a/jq/tests/data/CORR-DATA.json
+++ b/jq/tests/data/CORR-DATA.json
@@ -1,0 +1,42 @@
+{
+  "title":"CORR-DATA",
+  "description":"Corrosion is defined as the deterioration of a material due to chemical reactions with its environment. Understanding corrosion, and corrosion rates, is necessary to ensure that the design of objects we interact with every day, from the bridges we drive over to the containers used to transport chemicals, from the pipes that carry our water to the utensils we cook with, are safe and perform to specifications.\n\nThe Corr-Data dataset was created by the staff of the NACE-NIST Corrosion Data Program. This program was established by a joint agreement between NACE (National Association of Corrosion Engineers) International and NIST (National Institute of Standards and Technology) in Dec. of 1982 and ran until 1997. At its founding, the objective of this program was to provide engineers with software for the then new personal computers that would help them solve corrosion problems. Over the 15 years this program ran, over 20 databases and expert advisory systems for alloys selection were produced and released. While software can go out of date, the data remains relevant. The data describe observations of various samples in potentially corrosive environments under particular conditions (concentrations and temperatures) to see if, how, and at what rate they corrode. The data include over 24,000 records which have been extracted from over 250 different source documents.\n\nThe data provided here is from published results, but it should only be considered indicative of how the specified material was observed to perform in the given environment one time. The user needs to keep in mind that corrosion is a highly stochastic process and that behavior can vary greatly with small variations in the environment or material. This data is provided to help users select materials for further evaluation and should not be considered, or construed, as advice on the usability of any material in any environment. Only thoroughly evaluated test results for the whole range of material, loading, and environmental conditions should be used for critical decision making.",
+  "modified":"1997-01-01",
+  "publisher": {
+    "name":"National Institute of Standards and Technology",
+    "@type":"org:Organization"
+  },
+  "contactPoint": {
+    "fn":"Richard Ricker",
+    "hasEmail":"mailto:richard.ricker@nist.gov"
+  },
+  "identifier":"54AE54FB37AC022DE0531A570681D4291851",
+  "accessLevel":"public",
+  "license":"https://www.nist.gov/open/license",
+  "distribution": [
+    {
+      "accessURL":"https://researchdata.nist.gov/Materials-Physical-Properties/CORR-DATA-Database/akgq-mt9y",
+      "description":"This website gives users access to multiple download formats of the CORR-DATA data set.",
+      "title":"CORR-DATA"
+    },
+    {
+      "accessURL":"https://doi.org/10.18434/M3TH4R"
+    },
+    {
+      "downloadURL":"https://opendata.nist.gov/1851/CORR-DATA_Database.zip",
+      "mediaType":"text/plain"
+    },
+    {
+      "downloadURL":"https://opendata.nist.gov/1851/sha256/CORR-DATA_Database.zip.sha256",
+      "mediaType":"text/plain"
+    }
+  ],
+  "accrualPeriodicity":"irregular",
+  "landingPage":"https://researchdata.nist.gov/Materials-Physical-Properties/CORR-DATA-Database/akgq-mt9y",
+  "@type":"dcat:Dataset",
+  "keyword":["corrosion","NACE"],
+  "bureauCode":["006:55"],
+  "programCode":["006:052"],
+  "language":["en"],
+  "theme":["Metals","Materials characterization"]
+}

--- a/jq/tests/test_pod2nerdm.jqt
+++ b/jq/tests/test_pod2nerdm.jqt
@@ -10,28 +10,28 @@
 #
 include "pod2nerdm"; nerdm_schema
 null
-"https://www.nist.gov/od/dm/nerdm-schema/v0.1#"
+"https://data.nist.gov/od/dm/nerdm-schema/v0.1#"
 
 #--------------
 # testing nerdm_schema()
 #
 include "pod2nerdm"; nerdm_pub_schema
 null
-"https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#"
+"https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#"
 
 #--------------
 # testing nerdm_context()
 #
 include "pod2nerdm"; nerdm_context
 null
-"https://www.nist.gov/od/dm/nerdm-pub-context.jsonld"
+"https://data.nist.gov/od/dm/nerdm-pub-context.jsonld"
 
 #--------------
 # testing dciteRefType()
 #
 include "pod2nerdm"; dciteRefType
 null
-"https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
+"https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
 
 #--------------
 # testing resid()
@@ -49,14 +49,52 @@ null
 #
 include "pod2nerdm"; map(cvtref)
 [ "http://goob.net/doc1.txt", "https://goob.gov/doc2.txt" ]
-[{ "@type": "deo:BibliographicReference","@id":"#ref:doc1.txt", "refType": "IsReferencedBy", "_extensionSchemas": [ "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference" ], "location": "http://goob.net/doc1.txt"}, { "@type": "deo:BibliographicReference","@id":"#ref:doc2.txt", "refType": "IsReferencedBy", "_extensionSchemas": [ "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference" ], "location": "https://goob.gov/doc2.txt"}]
+[{ "@type": "deo:BibliographicReference","@id":"#ref:doc1.txt", "refType": "IsReferencedBy", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference" ], "location": "http://goob.net/doc1.txt"}, { "@type": "deo:BibliographicReference","@id":"#ref:doc2.txt", "refType": "IsReferencedBy", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference" ], "location": "https://goob.gov/doc2.txt"}]
 
 #---------------
 # testing urlpath()
 #
 include "pod2nerdm"; map(urlpath)
-[ "http://goob.net/doc1.txt", "https://goob.gov/gurn/doc2.txt", "file:/blah/blah", "http://dx.doi.org/10.082093/DOSFIASD", "https://www.nist.gov/od/ds/3A1EE2F169DD3B8CE0531A570681DB5D1491/trial3/trial3a.json" ]
+[ "http://goob.net/doc1.txt", "https://goob.gov/gurn/doc2.txt", "file:/blah/blah", "http://dx.doi.org/10.082093/DOSFIASD", "https://data.nist.gov/od/ds/3A1EE2F169DD3B8CE0531A570681DB5D1491/trial3/trial3a.json" ]
 [ "/doc1.txt", "/gurn/doc2.txt", "/blah/blah", "/10.082093/DOSFIASD", "/od/ds/3A1EE2F169DD3B8CE0531A570681DB5D1491/trial3/trial3a.json" ]
+
+#---------------
+# testing dirname()
+#
+include "pod2nerdm"; dirname
+"plainfile"
+""
+
+include "pod2nerdm"; dirname
+"foo/bar/now/plainfile"
+"foo/bar/now"
+
+include "pod2nerdm"; dirname
+"foo/plainfile"
+"foo"
+
+include "pod2nerdm"; dirname
+"foo/plainfile/"
+"foo"
+
+include "pod2nerdm"; dirname
+"foo/"
+""
+
+#---------------
+# testing remove elements
+#
+include "pod2nerdm"; remove_elements(["a", "a/b/c", "foo"])
+["a", "a/b", "a/b/c", "bar"]
+["a/b", "bar"]
+
+
+#---------------
+# testing ansc_coll_paths
+#
+include "pod2nerdm"; ansc_coll_paths
+["a/b/foo", "a/b/c/foo"]
+["a", "a/b", "a/b/c"]
 
 #---------------
 # testing componentID()
@@ -70,8 +108,8 @@ include "pod2nerdm"; map(componentID("#"))
 # testing dist2download()
 #
 include "pod2nerdm"; dist2download
-{"describedBy": "http://www.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-101.json", "mediaType": "application/json","title": "Titanium Boride" }
-{"describedBy": "http://www.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"]}
+{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json", "mediaType": "application/json","title": "Titanium Boride" }
+{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"]}
 
 #--------------
 # testing dist2hidden()
@@ -92,7 +130,7 @@ include "pod2nerdm"; dist2inaccess
 #
 include "pod2nerdm"; dist2accesspage
 {"accessURL": "https://doi.org/10.18434/T42C7D","title": "A Library to Enable the Modeling of Optical Imaging of Finite Multi-Line Arrays"}
-{"accessURL": "https://doi.org/10.18434/T42C7D","title": "A Library to Enable the Modeling of Optical Imaging of Finite Multi-Line Arrays","@type": [ "nrdp:AccessPage", "dcat:Distribution" ],"@id":"#10.18434/T42C7D","_extensionSchemas":["https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/AccessPage"]}
+{"accessURL": "https://doi.org/10.18434/T42C7D","title": "A Library to Enable the Modeling of Optical Imaging of Finite Multi-Line Arrays","@type": [ "nrdp:AccessPage", "dcat:Distribution" ],"@id":"#10.18434/T42C7D","_extensionSchemas":["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/AccessPage"]}
 
 #--------------
 # testing dist2comp()
@@ -110,8 +148,8 @@ include "pod2nerdm"; dist2comp
 # downloadURL).
 #
 include "pod2nerdm"; dist2comp
-{"describedBy": "http://www.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-101.json", "mediaType": "application/json","title": "Titanium Boride" }
-{"describedBy": "http://www.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"]}
+{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json", "mediaType": "application/json","title": "Titanium Boride" }
+{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"]}
 
 #--------------
 # testing dist2comp()
@@ -121,7 +159,7 @@ include "pod2nerdm"; dist2comp
 #
 include "pod2nerdm"; dist2comp
 {"accessURL": "http://www.nsrl.nist.gov/Downloads.htm","conformsTo": "http://www.nsrl.nist.gov/Documents/Data-Formats-of-the-NSRL-Reference-Data-Set-16.pdf","downloadURL": "http://www.nsrl.nist.gov/RDS/rds_2.50/RDS_250.iso","format": "ISO 9660 disk image","mediaType": "application/zip" }
-{"accessURL": "http://www.nsrl.nist.gov/Downloads.htm","conformsTo": "http://www.nsrl.nist.gov/Documents/Data-Formats-of-the-NSRL-Reference-Data-Set-16.pdf","downloadURL": "http://www.nsrl.nist.gov/RDS/rds_2.50/RDS_250.iso","format": { "description": "ISO 9660 disk image"},"mediaType": "application/zip", "filepath":"RDS_250.iso", "@type": ["nrdp:DataFile","dcat:Distribution"],"@id":"cmps/RDS_250.iso","_extensionSchemas": ["https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"] }
+{"accessURL": "http://www.nsrl.nist.gov/Downloads.htm","conformsTo": "http://www.nsrl.nist.gov/Documents/Data-Formats-of-the-NSRL-Reference-Data-Set-16.pdf","downloadURL": "http://www.nsrl.nist.gov/RDS/rds_2.50/RDS_250.iso","format": { "description": "ISO 9660 disk image"},"mediaType": "application/zip", "filepath":"RDS_250.iso", "@type": ["nrdp:DataFile","dcat:Distribution"],"@id":"cmps/RDS_250.iso","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"] }
 
 #--------------
 # testing dist2comp()
@@ -131,7 +169,7 @@ include "pod2nerdm"; dist2comp
 #
 include "pod2nerdm"; dist2comp
 {"accessURL": "http://webbook.nist.gov/chemistry/","description": "Landing page for the NIST Chemistry WebBook.","mediaType": "text/html"}
-{ "accessURL": "http://webbook.nist.gov/chemistry/","description": "Landing page for the NIST Chemistry WebBook.","mediaType": "text/html","@type": ["nrdp:AccessPage","dcat:Distribution"],"@id":"#chemistry/","_extensionSchemas":["https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/AccessPage"]}
+{ "accessURL": "http://webbook.nist.gov/chemistry/","description": "Landing page for the NIST Chemistry WebBook.","mediaType": "text/html","@type": ["nrdp:AccessPage","dcat:Distribution"],"@id":"#chemistry/","_extensionSchemas":["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/AccessPage"]}
 
 # testing dist2comp()
 #
@@ -228,6 +266,20 @@ include "pod2nerdm"; select_obj_type("gurn:Goober")
 include "pod2nerdm"; select_comp_type("nrdp:Subcollection"; "foo/bar")
 [{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{"title": "foo bar","filepath": "foo/bar","@type": ["nrdp:Subcollection"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
 [{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
+
+# testing create_subcoll_for
+#
+include "pod2nerdm"; create_subcoll_for
+"a/b/foo"
+{"@id": "cmps/a/b/foo", "@type": ["nrdp:Subcollection"], "filepath": "a/b/foo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection" ]}
+
+# testing insert_subcoll_comps
+#
+include "pod2nerdm"; insert_subcoll_comps
+[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
+[{"@id": "cmps/foo/bar", "@type": ["nrdp:Subcollection"], "filepath": "foo/bar", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection" ]},{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
+
+
 
 # testing select_comp_children
 #

--- a/jq/tests/test_pod2nerdm.jqt
+++ b/jq/tests/test_pod2nerdm.jqt
@@ -59,6 +59,28 @@ include "pod2nerdm"; map(urlpath)
 [ "/doc1.txt", "/gurn/doc2.txt", "/blah/blah", "/10.082093/DOSFIASD", "/od/ds/3A1EE2F169DD3B8CE0531A570681DB5D1491/trial3/trial3a.json" ]
 
 #---------------
+# testing trimsp
+#
+include "pod2nerdm"; trimsp
+"\t plainfile\n"
+"plainfile"
+
+#---------------
+# testing trimsp
+#
+include "pod2nerdm"; trimsp
+"plainfile"
+"plainfile"
+
+#---------------
+# testing trimsp
+#
+include "pod2nerdm"; trimsp
+"plainfile   "
+"plainfile"
+
+
+#---------------
 # testing dirname()
 #
 include "pod2nerdm"; dirname

--- a/model/examples/ceramicsportal.json
+++ b/model/examples/ceramicsportal.json
@@ -1,7 +1,7 @@
 {
-    "@context": "https://www.nist.gov/od/dm/nerdm-pub-context.jsonld",
-    "_schema": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#",
-    "_extensionSchemas": [ "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataPublication" ],
+    "@context": "https://data.nist.gov/od/dm/nerdm-pub-context.jsonld",
+    "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#",
+    "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataPublication" ],
 
     "@type": [ "nrdp:Portal", "nrdp:SRD", "nrdp:PublishedDataResource" ],
     "@id": "ark:/88434/sdp0fjspek352",
@@ -59,42 +59,42 @@
     "components": [
         { 
             "@type": [ "nrd:IncludedResource" ],
-            "_extensionSchemas": [ "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/IncludedResource" ],
+            "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/IncludedResource" ],
             "title": "NIST High Temperature Superconducting Materials Database - SRD 62",
             "proxyFor": "ark:/88434/sdp0fjspek353",
             "resType": [ "nrd:SRD", "nrd:Database", "nrd:DataPublication" ]
         },
         { 
             "@type": [ "nrd:IncludedResource" ],
-            "_extensionSchemas": [ "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/IncludedResource" ],
+            "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/IncludedResource" ],
             "title": "NIST Structural Ceramics Database - SRD 30",
             "proxyFor": "ark:/88434/sdp0fjspek354",
             "resType": [ "nrd:SRD", "nrd:Database", "nrd:DataPublication" ]
         },
         { 
             "@type": [ "nrd:IncludedResource" ],
-            "_extensionSchemas": [ "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/IncludedResource" ],
+            "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/IncludedResource" ],
             "title": "NIST Property Data Summaries for Advanced Materials - SRD 150",
             "proxyFor": "ark:/88434/sdp0fjspek355",
             "resType": [ "nrd:SRD", "nrd:DataPublication" ]
         },
         { 
             "@type": [ "nrd:IncludedResource" ],
-            "_extensionSchemas": [ "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/IncludedResource" ],
+            "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/IncludedResource" ],
             "title": "Elastic Moduli data for Polycrystalline Ceramics - NISTIR 6853",
             "proxyFor": "ark:/88434/sdp0fjspek354",
             "resType": [ "nrd:DataPublication" ]
         },
         { 
             "@type": [ "nrd:IncludedResource" ],
-            "_extensionSchemas": [ "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/IncludedResource" ],
+            "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/IncludedResource" ],
             "title": "Fracture Toughness/Fracture Energy Data for Oxide Glass - SRD 137",
             "proxyFor": "ark:/88434/sdp0fjspek354",
             "resType": [ "nrd:SRD", "nrd:DataPublication" ]
         },
         { 
             "@type": [ "nrd:IncludedResource" ],
-            "_extensionSchemas": [ "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/IncludedResource" ],
+            "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/IncludedResource" ],
             "title": "Fracture Toughness/Fracture Energy Data for - SRD 138",
             "proxyFor": "ark:/88434/sdp0fjspek354",
             "resType": [ "nrd:SRD", "nrd:DataPublication" ]

--- a/model/examples/hitsc.json
+++ b/model/examples/hitsc.json
@@ -1,7 +1,7 @@
 {
-    "@context": "https://www.nist.gov/od/dm/nerdm-pub-context.jsonld",
-    "_schema": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#",
-    "_extensionSchemas": [ "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataPublication" ],
+    "@context": "https://data.nist.gov/od/dm/nerdm-pub-context.jsonld",
+    "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#",
+    "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataPublication" ],
 
     "@type": [ "nrdp:Database", "nrdp:SRD", "nrdp:PublishedDataResource" ],
     "@id": "ark:/88434/sdp0fjspek353",
@@ -43,7 +43,7 @@
             "label": "User Manual",
             "location": "https://srdata.nist.gov/CeramicDataPortal/Manual/HtsHelper",
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
+                "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
             ]
         }
     ],

--- a/model/examples/janaf-hier.json
+++ b/model/examples/janaf-hier.json
@@ -1,7 +1,7 @@
 {
-    "@context": "https://www.nist.gov/od/dm/nerdm-pub-context.jsonld",
-    "_schema": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#",
-    "_extensionSchemas": [ "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataPublication" ],
+    "@context": "https://data.nist.gov/od/dm/nerdm-pub-context.jsonld",
+    "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#",
+    "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataPublication" ],
 
     "@type": [ "nrd:SRD", "nrdp:DataPublication", "nrdp:PublicDataResource" ],
     "@id": "ark:/88434/pdr02d4t",
@@ -114,7 +114,7 @@
             "label": "JPCRD Monograph: NIST-JANAF Thermochemical Tables, Pt. 1 (AL-C",
             "location": "http://kinetics.nist.gov/janaf/pdf/JANAF-FourthEd-1998-1Vol1-Intro.pdf",
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
+                "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
             ]
         },
         {
@@ -123,7 +123,7 @@
             "label": "JPCRD Monograph: NIST-JANAF Thermochemical Tables, Pt. 2 (Cr-Zr)",
             "location": "http://kinetics.nist.gov/janaf/pdf/JANAF-FourthEd-1998-1Vol2-Intro.pdf",
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
+                "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
             ]
         }
     ],
@@ -2116,7 +2116,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "borides",
             "title": "Metal Borides"
@@ -2124,7 +2124,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "borides/titanium",
             "title": "Titanium Boride"
@@ -2132,7 +2132,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borides/titanium/srd13_B-102.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-102.json",
@@ -2143,7 +2143,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borides/titanium/srd13_B-101.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-101.json",
@@ -2154,7 +2154,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "borides/zirconium",
             "title": "Zirconium Boride"
@@ -2162,7 +2162,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borides/zirconium/srd13_B-103.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-103.json",
@@ -2174,7 +2174,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borides/zirconium/srd13_B-104.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-104.json",
@@ -2186,7 +2186,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borides/zirconium/srd13_B-105.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-105.json",
@@ -2198,7 +2198,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "boroxins",
             "title": "Boroxins"
@@ -2206,7 +2206,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boroxins/srd13_B-106.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-106.json",
@@ -2218,7 +2218,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boroxins/srd13_B-107.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-107.json",
@@ -2230,7 +2230,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boroxins/srd13_B-108.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-108.json",
@@ -2242,7 +2242,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boroxins/srd13_B-109.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-109.json",
@@ -2254,7 +2254,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boroxins/srd13_B-110.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-110.json",
@@ -2266,7 +2266,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boroxins/srd13_B-111.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-111.json",
@@ -2278,7 +2278,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boroxins/srd13_B-112.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-112.json",
@@ -2290,7 +2290,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-113.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-113.json",
@@ -2302,7 +2302,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-114.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-114.json",
@@ -2314,7 +2314,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "borates",
             "title": "Borates"
@@ -2322,7 +2322,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "borates/potassium",
             "title": "Potassium Borate"
@@ -2330,7 +2330,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/potassium/srd13_B-115.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-115.json",
@@ -2342,7 +2342,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-116.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-116.json",
@@ -2354,7 +2354,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-117.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-117.json",
@@ -2366,7 +2366,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "borates/lithium",
             "title": "Lithium Borate"
@@ -2374,7 +2374,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/lithium/srd13_B-118.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-118.json",
@@ -2386,7 +2386,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-119.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-119.json",
@@ -2397,7 +2397,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/lithium/srd13_B-120.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-120.json",
@@ -2409,7 +2409,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "borides/magnesium",
             "title": "Magnesium Boride"
@@ -2417,7 +2417,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borides/magnesium/srd13_B-121.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-121.json",
@@ -2429,7 +2429,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "borates/sodium",
             "title": "Sodium Borate"
@@ -2437,7 +2437,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/sodium/srd13_B-122.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-122.json",
@@ -2449,7 +2449,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/sodium/srd13_B-123.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-123.json",
@@ -2461,7 +2461,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/sodium/srd13_B-124.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-124.json",
@@ -2473,7 +2473,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "borates/lead",
             "title": "Lead Borate"
@@ -2481,7 +2481,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/lead/srd13_B-125.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-125.json",
@@ -2493,7 +2493,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "boranes",
             "title": "Boranes"
@@ -2501,7 +2501,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "boranes/pentaborane",
             "title": "Pentaborane"
@@ -2509,7 +2509,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/pentaborane/srd13_B-126.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-126.json",
@@ -2521,7 +2521,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/pentaborane/srd13_B-127.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-127.json",
@@ -2533,7 +2533,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/potassium/srd13_B-128.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-128.json",
@@ -2545,7 +2545,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/lithium/srd13_B-129.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-129.json",
@@ -2557,7 +2557,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/sodium/srd13_B-130.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-130.json",
@@ -2569,7 +2569,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/lead/srd13_B-131.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-131.json",
@@ -2581,7 +2581,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/potassium/srd13_B-132.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-132.json",
@@ -2593,7 +2593,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/potassium/srd13_B-133.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-133.json",
@@ -2605,7 +2605,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/potassium/srd13_B-134.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-134.json",
@@ -2617,7 +2617,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/lithium/srd13_B-135.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-135.json",
@@ -2629,7 +2629,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "boranes/decaborane",
             "title": "Decaaborane"
@@ -2637,7 +2637,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/decaborane/srd13_B-136.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-136.json",
@@ -2649,7 +2649,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/decaborane/srd13_B-137.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-137.json",
@@ -2661,7 +2661,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/decaborane/srd13_B-138.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-138.json",
@@ -2673,7 +2673,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-139.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-139.json",
@@ -2685,7 +2685,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_janaf-zipfile.zip",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_janaf-zipfile.zip",
@@ -2696,7 +2696,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
 
             "filepath": "srd13_janaf.species.json",
@@ -2708,7 +2708,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "aluminum",
             "title": "Aluminum and Aluminum compounds"
@@ -2716,7 +2716,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "aluminum/aluminum",
             "title": "Aluminum"
@@ -2724,7 +2724,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/aluminum/srd13_Al-001.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-001.json",
@@ -2736,7 +2736,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/aluminum/srd13_Al-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-002.json",
@@ -2748,7 +2748,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/aluminum/srd13_Al-003.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-003.json",
@@ -2760,7 +2760,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/aluminum/srd13_Al-004.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-004.json",
@@ -2772,7 +2772,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/aluminum/srd13_Al-005.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-005.json",
@@ -2784,7 +2784,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "aluminum/ion",
             "title": "Aluminum, Ion"
@@ -2792,7 +2792,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/ion/srd13_Al-006.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-006.json",
@@ -2804,7 +2804,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/ion/srd13_Al-007.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-007.json",
@@ -2816,7 +2816,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "borates/aluminum",
             "title": "Aluminum Borate"
@@ -2824,7 +2824,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/aluminum/srd13_Al-008.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-008.json",
@@ -2836,7 +2836,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "bromides",
             "title": "Bromides"
@@ -2844,7 +2844,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "bromides/aluminum",
             "title": "Aluminum Bromide"
@@ -2852,7 +2852,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/aluminum/srd13_Al-009.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-009.json",
@@ -2864,7 +2864,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/aluminum/srd13_Al-010.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-010.json",
@@ -2876,7 +2876,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/aluminum/srd13_Al-011.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-011.json",
@@ -2888,7 +2888,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/aluminum/srd13_Al-012.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-012.json",
@@ -2900,7 +2900,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/aluminum/srd13_Al-013.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-013.json",
@@ -2912,7 +2912,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "aluminum/chloride",
             "title": "Aluminum Chloride compounds"
@@ -2920,7 +2920,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-014.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-014.json",
@@ -2932,7 +2932,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-015.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-015.json",
@@ -2944,7 +2944,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-016.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-016.json",
@@ -2956,7 +2956,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-017.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-017.json",
@@ -2968,7 +2968,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-018.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-018.json",
@@ -2980,7 +2980,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-019.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-019.json",
@@ -2992,7 +2992,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-020.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-020.json",
@@ -3004,7 +3004,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-021.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-021.json",
@@ -3016,7 +3016,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-022.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-022.json",
@@ -3028,7 +3028,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-023.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-023.json",
@@ -3040,7 +3040,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-024.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-024.json",
@@ -3052,7 +3052,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-025.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-025.json",
@@ -3064,7 +3064,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-026.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-026.json",
@@ -3076,7 +3076,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-027.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-027.json",
@@ -3088,7 +3088,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-028.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-028.json",
@@ -3100,7 +3100,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "luminates",
             "title": "Luminate compounds"
@@ -3108,7 +3108,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "luminates/srd13_Al-029.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-029.json",
@@ -3120,7 +3120,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "luminates/srd13_Al-030.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-030.json",
@@ -3132,7 +3132,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "luminates/srd13_Al-031.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-031.json",
@@ -3144,7 +3144,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "luminates/srd13_Al-032.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-032.json",
@@ -3156,7 +3156,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "aluminum/fluoride",
             "title": "Aluminum Fluoride compounds"
@@ -3164,7 +3164,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/fluoride/srd13_Al-033.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-033.json",
@@ -3176,7 +3176,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/fluoride/srd13_Al-034.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-034.json",
@@ -3188,7 +3188,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/fluoride/srd13_Al-035.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-035.json",
@@ -3200,7 +3200,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/fluoride/srd13_Al-036.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-036.json",
@@ -3212,7 +3212,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/fluoride/srd13_Al-037.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-037.json",
@@ -3224,7 +3224,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/fluoride/srd13_Al-038.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-038.json",
@@ -3236,7 +3236,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/fluoride/srd13_Al-039.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-039.json",
@@ -3248,7 +3248,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/fluoride/srd13_Al-040.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-040.json",
@@ -3260,7 +3260,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/fluoride/srd13_Al-041.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-041.json",
@@ -3272,7 +3272,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/fluoride/srd13_Al-042.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-042.json",
@@ -3284,7 +3284,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/fluoride/srd13_Al-043.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-043.json",
@@ -3296,7 +3296,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/fluoride/srd13_Al-044.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-044.json",
@@ -3308,7 +3308,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "luminates/srd13_Al-045.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-045.json",
@@ -3320,7 +3320,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "luminates/srd13_Al-046.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-046.json",
@@ -3332,7 +3332,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "luminates/srd13_Al-047.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-047.json",
@@ -3344,7 +3344,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "luminates/srd13_Al-048.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-048.json",
@@ -3356,7 +3356,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "luminates/srd13_Al-049.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-049.json",
@@ -3368,7 +3368,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "luminates/srd13_Al-050.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-050.json",
@@ -3380,7 +3380,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "luminates/srd13_Al-051.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-051.json",
@@ -3392,7 +3392,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "cryolite",
             "title": "Cryolite"
@@ -3400,7 +3400,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "cryolite/srd13_Al-052.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-052.json",
@@ -3412,7 +3412,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "cryolite/srd13_Al-053.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-053.json",
@@ -3424,7 +3424,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "cryolite/srd13_Al-054.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-054.json",
@@ -3436,7 +3436,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "cryolite/srd13_Al-055.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-055.json",
@@ -3448,7 +3448,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "aluminum/hydride",
             "title": "Aluminum Hydride compounds"
@@ -3456,7 +3456,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/hydride/srd13_Al-056.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-056.json",
@@ -3468,7 +3468,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/hydride/srd13_Al-057.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-057.json",
@@ -3480,7 +3480,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "aluminum/hydoxide",
             "title": "Aluminum Hydroxide compounds"
@@ -3488,7 +3488,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/hydoxide/srd13_Al-058.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-058.json",
@@ -3500,7 +3500,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/hydoxide/srd13_Al-059.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-059.json",
@@ -3512,7 +3512,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/hydoxide/srd13_Al-060.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-060.json",
@@ -3524,7 +3524,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/hydoxide/srd13_Al-061.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-061.json",
@@ -3536,7 +3536,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "luminates/srd13_Al-062.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-062.json",
@@ -3548,7 +3548,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "aluminum/iodide",
             "title": "Aluminum Iodide"
@@ -3556,7 +3556,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/iodide/srd13_Al-063.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-063.json",
@@ -3568,7 +3568,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/iodide/srd13_Al-064.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-064.json",
@@ -3580,7 +3580,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/iodide/srd13_Al-065.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-065.json",
@@ -3592,7 +3592,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/iodide/srd13_Al-066.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-066.json",
@@ -3604,7 +3604,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/iodide/srd13_Al-067.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-067.json",
@@ -3616,7 +3616,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "aluminum/oxide",
             "title": "Aluminum Oxide compounds"
@@ -3624,7 +3624,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-068.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-068.json",
@@ -3636,7 +3636,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-069.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-069.json",
@@ -3648,7 +3648,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-070.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-070.json",
@@ -3660,7 +3660,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "aluminum/nitride",
             "title": "Aluminum Nitride"
@@ -3668,7 +3668,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/nitride/srd13_Al-071.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-071.json",
@@ -3680,7 +3680,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/nitride/srd13_Al-072.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-072.json",
@@ -3692,7 +3692,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-073.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-073.json",
@@ -3704,7 +3704,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-074.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-074.json",
@@ -3716,7 +3716,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-075.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-075.json",
@@ -3728,7 +3728,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-076.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-076.json",
@@ -3740,7 +3740,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-077.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-077.json",
@@ -3752,7 +3752,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-078.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-078.json",
@@ -3764,7 +3764,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/srd13_Al-079.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-079.json",
@@ -3776,7 +3776,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/srd13_Al-080.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-080.json",
@@ -3788,7 +3788,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-081.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-081.json",
@@ -3800,7 +3800,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-082.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-082.json",
@@ -3812,7 +3812,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-083.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-083.json",
@@ -3824,7 +3824,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/aluminum/srd13_Al-084.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-084.json",
@@ -3836,7 +3836,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-085.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-085.json",
@@ -3848,7 +3848,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "radon",
             "title": "Radon"
@@ -3856,7 +3856,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "radon/srd13_Rn-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Rn-002.json",
@@ -3868,7 +3868,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/chloride/srd13_Al-086.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-086.json",
@@ -3880,7 +3880,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/fluoride/srd13_Al-087.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-087.json",
@@ -3891,7 +3891,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/iodide/srd13_Al-088.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-088.json",
@@ -3903,7 +3903,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-089.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-089.json",
@@ -3915,7 +3915,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-090.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-090.json",
@@ -3927,7 +3927,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-091.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-091.json",
@@ -3939,7 +3939,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-092.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-092.json",
@@ -3951,7 +3951,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-093.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-093.json",
@@ -3963,7 +3963,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-094.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-094.json",
@@ -3975,7 +3975,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-095.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-095.json",
@@ -3987,7 +3987,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-096.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-096.json",
@@ -3999,7 +3999,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-097.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-097.json",
@@ -4011,7 +4011,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-098.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-098.json",
@@ -4023,7 +4023,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-099.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-099.json",
@@ -4035,7 +4035,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-100.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-100.json",
@@ -4047,7 +4047,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-101.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-101.json",
@@ -4059,7 +4059,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "aluminum/silicate",
             "title": "Aluminum Silicate"
@@ -4067,7 +4067,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/silicate/srd13_Al-102.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-102.json",
@@ -4079,7 +4079,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/silicate/srd13_Al-103.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-103.json",
@@ -4091,7 +4091,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/silicate/srd13_Al-104.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-104.json",
@@ -4103,7 +4103,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/srd13_Al-105.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-105.json",
@@ -4115,7 +4115,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "chiolite",
             "title": "Chiolite"
@@ -4123,7 +4123,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "chiolite/srd13_Al-106.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-106.json",
@@ -4135,7 +4135,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "chiolite/srd13_Al-107.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-107.json",
@@ -4147,7 +4147,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "chiolite/srd13_Al-108.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-108.json",
@@ -4159,7 +4159,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-109.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-109.json",
@@ -4171,7 +4171,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-110.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-110.json",
@@ -4183,7 +4183,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/oxide/srd13_Al-111.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-111.json",
@@ -4195,7 +4195,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "aluminum/silicate/srd13_Al-112.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-112.json",
@@ -4207,7 +4207,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "argon",
             "title": "Argon"
@@ -4215,7 +4215,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "argon/srd13_Ar-001.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ar-001.json",
@@ -4227,7 +4227,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "argon/srd13_Ar-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ar-002.json",
@@ -4239,7 +4239,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "boron",
             "title": "Boron and Boron compounds"
@@ -4247,7 +4247,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-001.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-001.json",
@@ -4259,7 +4259,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-002.json",
@@ -4271,7 +4271,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-003.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-003.json",
@@ -4283,7 +4283,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-004.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-004.json",
@@ -4295,7 +4295,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-005.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-005.json",
@@ -4307,7 +4307,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-006.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-006.json",
@@ -4319,7 +4319,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-007.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-007.json",
@@ -4331,7 +4331,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "borates/beryllium",
             "title": "Beryllium Borate"
@@ -4339,7 +4339,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/beryllium/srd13_B-008.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-008.json",
@@ -4351,7 +4351,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-009.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-009.json",
@@ -4363,7 +4363,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-010.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-010.json",
@@ -4375,7 +4375,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-011.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-011.json",
@@ -4387,7 +4387,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-012.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-012.json",
@@ -4399,7 +4399,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-013.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-013.json",
@@ -4411,7 +4411,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_B-014.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-014.json",
@@ -4423,7 +4423,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-015.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-015.json",
@@ -4435,7 +4435,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-016.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-016.json",
@@ -4447,7 +4447,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-017.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-017.json",
@@ -4459,7 +4459,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-018.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-018.json",
@@ -4471,7 +4471,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-019.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-019.json",
@@ -4483,7 +4483,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-020.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-020.json",
@@ -4495,7 +4495,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-021.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-021.json",
@@ -4507,7 +4507,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-022.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-022.json",
@@ -4519,7 +4519,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-023.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-023.json",
@@ -4531,7 +4531,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-024.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-024.json",
@@ -4543,7 +4543,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-025.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-025.json",
@@ -4555,7 +4555,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-026.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-026.json",
@@ -4567,7 +4567,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-027.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-027.json",
@@ -4579,7 +4579,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-028.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-028.json",
@@ -4591,7 +4591,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-029.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-029.json",
@@ -4603,7 +4603,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-030.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-030.json",
@@ -4615,7 +4615,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-031.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-031.json",
@@ -4627,7 +4627,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-032.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-032.json",
@@ -4639,7 +4639,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-033.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-033.json",
@@ -4651,7 +4651,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-034.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-034.json",
@@ -4663,7 +4663,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-035.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-035.json",
@@ -4675,7 +4675,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-036.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-036.json",
@@ -4687,7 +4687,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-037.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-037.json",
@@ -4699,7 +4699,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-038.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-038.json",
@@ -4711,7 +4711,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-039.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-039.json",
@@ -4723,7 +4723,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-040.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-040.json",
@@ -4735,7 +4735,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/potassium/srd13_B-041.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-041.json",
@@ -4747,7 +4747,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/potassium/srd13_B-042.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-042.json",
@@ -4759,7 +4759,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/potassium/srd13_B-043.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-043.json",
@@ -4771,7 +4771,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/potassium/srd13_B-044.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-044.json",
@@ -4783,7 +4783,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-045.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-045.json",
@@ -4795,7 +4795,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-046.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-046.json",
@@ -4807,7 +4807,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-047.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-047.json",
@@ -4819,7 +4819,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-048.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-048.json",
@@ -4831,7 +4831,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-049.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-049.json",
@@ -4843,7 +4843,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-050.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-050.json",
@@ -4855,7 +4855,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-051.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-051.json",
@@ -4867,7 +4867,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-052.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-052.json",
@@ -4879,7 +4879,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-053.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-053.json",
@@ -4891,7 +4891,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-054.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-054.json",
@@ -4903,7 +4903,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-055.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-055.json",
@@ -4915,7 +4915,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-056.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-056.json",
@@ -4927,7 +4927,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-057.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-057.json",
@@ -4939,7 +4939,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/potassium/srd13_B-058.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-058.json",
@@ -4951,7 +4951,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/lithium/srd13_B-059.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-059.json",
@@ -4963,7 +4963,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/sodium/srd13_B-060.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-060.json",
@@ -4975,7 +4975,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-061.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-061.json",
@@ -4987,7 +4987,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-062.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-062.json",
@@ -4999,7 +4999,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-063.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-063.json",
@@ -5011,7 +5011,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/potassium/srd13_B-064.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-064.json",
@@ -5023,7 +5023,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/potassium/srd13_B-065.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-065.json",
@@ -5035,7 +5035,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/potassium/srd13_B-066.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-066.json",
@@ -5047,7 +5047,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/potassium/srd13_B-067.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-067.json",
@@ -5059,7 +5059,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/lithium/srd13_B-068.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-068.json",
@@ -5071,7 +5071,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/lithium/srd13_B-069.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-069.json",
@@ -5083,7 +5083,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/lithium/srd13_B-070.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-070.json",
@@ -5095,7 +5095,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/lithium/srd13_B-071.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-071.json",
@@ -5107,7 +5107,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-072.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-072.json",
@@ -5119,7 +5119,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-073.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-073.json",
@@ -5131,7 +5131,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/sodium/srd13_B-074.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-074.json",
@@ -5143,7 +5143,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/sodium/srd13_B-075.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-075.json",
@@ -5155,7 +5155,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/sodium/srd13_B-076.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-076.json",
@@ -5167,7 +5167,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/sodium/srd13_B-077.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-077.json",
@@ -5179,7 +5179,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-078.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-078.json",
@@ -5191,7 +5191,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-079.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-079.json",
@@ -5203,7 +5203,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-080.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-080.json",
@@ -5215,7 +5215,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-081.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-081.json",
@@ -5227,7 +5227,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borides/titanium/srd13_B-082.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-082.json",
@@ -5239,7 +5239,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-083.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-083.json",
@@ -5251,7 +5251,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/beryllium/srd13_B-084.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-084.json",
@@ -5263,7 +5263,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/beryllium/srd13_B-085.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-085.json",
@@ -5275,7 +5275,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-086.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-086.json",
@@ -5287,7 +5287,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-087.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-087.json",
@@ -5299,7 +5299,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-088.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-088.json",
@@ -5311,7 +5311,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-089.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-089.json",
@@ -5323,7 +5323,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-090.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-090.json",
@@ -5335,7 +5335,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boranes/srd13_B-091.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-091.json",
@@ -5347,7 +5347,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borides/magnesium/srd13_B-092.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-092.json",
@@ -5359,7 +5359,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-093.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-093.json",
@@ -5371,7 +5371,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-094.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-094.json",
@@ -5383,7 +5383,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-095.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-095.json",
@@ -5395,7 +5395,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-096.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-096.json",
@@ -5407,7 +5407,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-097.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-097.json",
@@ -5419,7 +5419,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "boron/srd13_B-098.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-098.json",
@@ -5431,7 +5431,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/lead/srd13_B-099.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-099.json",
@@ -5443,7 +5443,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borides/titanium/srd13_B-100.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-100.json",
@@ -5455,7 +5455,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "borates/lead/srd13_B-140.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-140.json",
@@ -5467,7 +5467,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "barium",
             "title": "Barium"
@@ -5475,7 +5475,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "barium/srd13_Ba-001.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ba-001.json",
@@ -5487,7 +5487,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "barium/srd13_Ba-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ba-002.json",
@@ -5499,7 +5499,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "barium/srd13_Ba-003.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ba-003.json",
@@ -5511,7 +5511,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "bromides/calcium",
             "title": "Calcium Bromide"
@@ -5519,7 +5519,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/calcium/srd13_Br-004.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-004.json",
@@ -5531,7 +5531,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "bromines",
             "title": "Bromimes"
@@ -5539,7 +5539,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromines/srd13_Br-005.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-005.json",
@@ -5551,7 +5551,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromines/srd13_Br-006.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-006.json",
@@ -5563,7 +5563,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromines/srd13_Br-007.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-007.json",
@@ -5575,7 +5575,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromines/srd13_Br-008.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-008.json",
@@ -5587,7 +5587,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-009.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-009.json",
@@ -5599,7 +5599,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-010.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-010.json",
@@ -5611,7 +5611,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-011.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-011.json",
@@ -5623,7 +5623,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-012.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-012.json",
@@ -5635,7 +5635,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-013.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-013.json",
@@ -5647,7 +5647,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-014.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-014.json",
@@ -5659,7 +5659,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "bromides/potassium",
             "title": "Potassium Bromide"
@@ -5667,7 +5667,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/potassium/srd13_Br-015.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-015.json",
@@ -5678,7 +5678,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/potassium/srd13_Br-016.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-016.json",
@@ -5690,7 +5690,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/potassium/srd13_Br-017.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-017.json",
@@ -5702,7 +5702,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/potassium/srd13_Br-018.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-018.json",
@@ -5714,7 +5714,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "bromides/lithium",
             "title": "Lithium Bromide"
@@ -5722,7 +5722,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/lithium/srd13_Br-019.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-019.json",
@@ -5734,7 +5734,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/lithium/srd13_Br-020.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-020.json",
@@ -5746,7 +5746,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/lithium/srd13_Br-021.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-021.json",
@@ -5758,7 +5758,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/lithium/srd13_Br-022.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-022.json",
@@ -5770,7 +5770,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-023.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-023.json",
@@ -5782,7 +5782,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-024.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-024.json",
@@ -5794,7 +5794,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-025.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-025.json",
@@ -5806,7 +5806,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-026.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-026.json",
@@ -5818,7 +5818,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-027.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-027.json",
@@ -5830,7 +5830,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "bromides/sodium",
             "title": "Sodium Bromide"
@@ -5838,7 +5838,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/sodium/srd13_Br-028.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-028.json",
@@ -5850,7 +5850,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/sodium/srd13_Br-029.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-029.json",
@@ -5862,7 +5862,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/sodium/srd13_Br-030.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-030.json",
@@ -5874,7 +5874,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-031.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-031.json",
@@ -5886,7 +5886,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-032.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-032.json",
@@ -5898,7 +5898,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-033.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-033.json",
@@ -5910,7 +5910,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-034.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-034.json",
@@ -5922,7 +5922,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-035.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-035.json",
@@ -5934,7 +5934,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-036.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-036.json",
@@ -5946,7 +5946,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/srd13_Br-037.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-037.json",
@@ -5958,7 +5958,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromines/srd13_Br-038.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-038.json",
@@ -5970,7 +5970,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromines/srd13_Br-039.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-039.json",
@@ -5982,7 +5982,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromines/srd13_Br-040.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-040.json",
@@ -5994,7 +5994,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/calcium/srd13_Br-041.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-041.json",
@@ -6006,7 +6006,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/calcium/srd13_Br-042.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-042.json",
@@ -6018,7 +6018,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/calcium/srd13_Br-043.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-043.json",
@@ -6030,7 +6030,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/calcium/srd13_Br-044.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-044.json",
@@ -6042,7 +6042,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "bromides/iron",
             "title": "Iron Bromide"
@@ -6050,7 +6050,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/iron/srd13_Br-045.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-045.json",
@@ -6062,7 +6062,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/iron/srd13_Br-046.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-046.json",
@@ -6074,7 +6074,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/iron/srd13_Br-047.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-047.json",
@@ -6086,7 +6086,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/iron/srd13_Br-048.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-048.json",
@@ -6098,7 +6098,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-049.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-049.json",
@@ -6110,7 +6110,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "bromides/mercury",
             "title": "Mercury Bromide"
@@ -6118,7 +6118,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/mercury/srd13_Br-050.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-050.json",
@@ -6130,7 +6130,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/mercury/srd13_Br-051.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-051.json",
@@ -6142,7 +6142,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/mercury/srd13_Br-052.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-052.json",
@@ -6154,7 +6154,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/mercury/srd13_Br-053.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-053.json",
@@ -6166,7 +6166,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/mercury/srd13_Br-054.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-054.json",
@@ -6178,7 +6178,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/potassium/srd13_Br-055.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-055.json",
@@ -6190,7 +6190,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/lithium/srd13_Br-056.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-056.json",
@@ -6202,7 +6202,7 @@
         {
             "@type": [ "nrdp:Subcollection" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection"
             ],
             "filepath": "bromides/magnesium",
             "title": "Magnesium Bromide"
@@ -6210,7 +6210,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/magnesium/srd13_Br-057.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-057.json",
@@ -6222,7 +6222,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/magnesium/srd13_Br-058.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-058.json",
@@ -6234,7 +6234,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/magnesium/srd13_Br-059.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-059.json",
@@ -6246,7 +6246,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/magnesium/srd13_Br-060.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-060.json",
@@ -6258,7 +6258,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "bromides/magnesium/srd13_Br-061.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-061.json",

--- a/model/examples/janaf.json
+++ b/model/examples/janaf.json
@@ -1,7 +1,7 @@
 {
-    "@context": "https://www.nist.gov/od/dm/nerdm-pub-context.jsonld",
-    "_schema": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#",
-    "_extensionSchemas": [ "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataPublication" ],
+    "@context": "https://data.nist.gov/od/dm/nerdm-pub-context.jsonld",
+    "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#",
+    "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataPublication" ],
 
     "@type": [ "nrd:SRD", "nrdp:DataPublication", "nrdp:PublicDataResource" ],
     "@id": "ark:/88434/sdp0fjspek351",
@@ -114,7 +114,7 @@
             "label": "JPCRD Monograph: NIST-JANAF Thermochemical Tables, Pt. 1 (AL-C",
             "location": "http://kinetics.nist.gov/janaf/pdf/JANAF-FourthEd-1998-1Vol1-Intro.pdf",
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
+                "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
             ]
         },
         {
@@ -123,7 +123,7 @@
             "label": "JPCRD Monograph: NIST-JANAF Thermochemical Tables, Pt. 2 (Cr-Zr)",
             "location": "http://kinetics.nist.gov/janaf/pdf/JANAF-FourthEd-1998-1Vol2-Intro.pdf",
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
+                "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
             ]
         }
     ],
@@ -473,7 +473,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-101.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-101.json",
@@ -484,7 +484,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-102.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-102.json",
@@ -495,7 +495,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-103.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-103.json",
@@ -506,7 +506,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-104.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-104.json",
@@ -517,7 +517,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-105.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-105.json",
@@ -528,7 +528,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-106.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-106.json",
@@ -539,7 +539,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-107.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-107.json",
@@ -550,7 +550,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-108.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-108.json",
@@ -561,7 +561,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-109.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-109.json",
@@ -572,7 +572,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-110.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-110.json",
@@ -583,7 +583,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-111.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-111.json",
@@ -594,7 +594,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-112.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-112.json",
@@ -605,7 +605,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-113.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-113.json",
@@ -616,7 +616,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-114.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-114.json",
@@ -627,7 +627,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-115.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-115.json",
@@ -638,7 +638,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-116.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-116.json",
@@ -649,7 +649,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-117.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-117.json",
@@ -660,7 +660,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-118.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-118.json",
@@ -671,7 +671,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-119.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-119.json",
@@ -682,7 +682,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-120.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-120.json",
@@ -693,7 +693,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-121.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-121.json",
@@ -704,7 +704,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-122.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-122.json",
@@ -715,7 +715,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-123.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-123.json",
@@ -726,7 +726,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-124.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-124.json",
@@ -737,11 +737,11 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-125.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-125.json",
@@ -752,11 +752,11 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-126.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-126.json",
@@ -767,7 +767,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-127.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-127.json",
@@ -778,7 +778,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-128.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-128.json",
@@ -789,7 +789,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-129.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-129.json",
@@ -800,7 +800,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-130.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-130.json",
@@ -811,7 +811,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-131.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-131.json",
@@ -822,7 +822,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-132.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-132.json",
@@ -833,7 +833,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-133.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-133.json",
@@ -844,7 +844,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-134.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-134.json",
@@ -855,7 +855,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-135.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-135.json",
@@ -866,7 +866,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-136.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-136.json",
@@ -877,7 +877,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-137.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-137.json",
@@ -888,7 +888,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-138.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-138.json",
@@ -899,7 +899,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-139.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-139.json",
@@ -910,7 +910,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_janaf-zipfile.zip",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_janaf-zipfile.zip",
@@ -921,7 +921,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
 
             "filepath": "srd13_janaf.species.json",
@@ -933,7 +933,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-001.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-001.json",
@@ -944,7 +944,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-002.json",
@@ -955,7 +955,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-003.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-003.json",
@@ -966,7 +966,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-004.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-004.json",
@@ -977,7 +977,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-005.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-005.json",
@@ -988,7 +988,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-006.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-006.json",
@@ -999,7 +999,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-007.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-007.json",
@@ -1010,7 +1010,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-008.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-008.json",
@@ -1021,7 +1021,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-009.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-009.json",
@@ -1032,7 +1032,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-010.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-010.json",
@@ -1043,7 +1043,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-011.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-011.json",
@@ -1054,7 +1054,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-012.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-012.json",
@@ -1065,7 +1065,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-013.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-013.json",
@@ -1076,7 +1076,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-014.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-014.json",
@@ -1087,7 +1087,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-015.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-015.json",
@@ -1098,7 +1098,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-016.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-016.json",
@@ -1109,7 +1109,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-017.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-017.json",
@@ -1120,7 +1120,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-018.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-018.json",
@@ -1131,7 +1131,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-019.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-019.json",
@@ -1142,7 +1142,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-020.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-020.json",
@@ -1153,7 +1153,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-021.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-021.json",
@@ -1164,7 +1164,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-022.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-022.json",
@@ -1175,7 +1175,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-023.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-023.json",
@@ -1186,7 +1186,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-024.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-024.json",
@@ -1197,7 +1197,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-025.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-025.json",
@@ -1208,7 +1208,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-026.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-026.json",
@@ -1219,7 +1219,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-027.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-027.json",
@@ -1230,7 +1230,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-028.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-028.json",
@@ -1241,7 +1241,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-029.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-029.json",
@@ -1252,7 +1252,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-030.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-030.json",
@@ -1263,7 +1263,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-031.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-031.json",
@@ -1274,7 +1274,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-032.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-032.json",
@@ -1285,7 +1285,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-033.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-033.json",
@@ -1296,7 +1296,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-034.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-034.json",
@@ -1307,7 +1307,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-035.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-035.json",
@@ -1318,7 +1318,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-036.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-036.json",
@@ -1329,7 +1329,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-037.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-037.json",
@@ -1340,7 +1340,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-038.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-038.json",
@@ -1351,7 +1351,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-039.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-039.json",
@@ -1362,7 +1362,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-040.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-040.json",
@@ -1373,7 +1373,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-041.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-041.json",
@@ -1384,7 +1384,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-042.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-042.json",
@@ -1395,7 +1395,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-043.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-043.json",
@@ -1406,7 +1406,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-044.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-044.json",
@@ -1417,7 +1417,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-045.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-045.json",
@@ -1428,7 +1428,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-046.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-046.json",
@@ -1439,7 +1439,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-047.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-047.json",
@@ -1450,7 +1450,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-048.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-048.json",
@@ -1461,7 +1461,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-049.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-049.json",
@@ -1472,7 +1472,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-050.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-050.json",
@@ -1483,7 +1483,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-051.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-051.json",
@@ -1494,7 +1494,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-052.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-052.json",
@@ -1505,7 +1505,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-053.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-053.json",
@@ -1516,7 +1516,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-054.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-054.json",
@@ -1527,7 +1527,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-055.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-055.json",
@@ -1538,7 +1538,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-056.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-056.json",
@@ -1549,7 +1549,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-057.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-057.json",
@@ -1560,7 +1560,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-058.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-058.json",
@@ -1571,7 +1571,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-059.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-059.json",
@@ -1582,7 +1582,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-060.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-060.json",
@@ -1593,7 +1593,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-061.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-061.json",
@@ -1604,7 +1604,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-062.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-062.json",
@@ -1615,7 +1615,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-063.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-063.json",
@@ -1626,7 +1626,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-064.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-064.json",
@@ -1637,7 +1637,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-065.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-065.json",
@@ -1648,7 +1648,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-066.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-066.json",
@@ -1659,7 +1659,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-067.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-067.json",
@@ -1670,7 +1670,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-068.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-068.json",
@@ -1681,7 +1681,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-069.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-069.json",
@@ -1692,7 +1692,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-070.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-070.json",
@@ -1703,7 +1703,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-071.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-071.json",
@@ -1714,7 +1714,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-072.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-072.json",
@@ -1725,7 +1725,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-073.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-073.json",
@@ -1736,7 +1736,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-074.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-074.json",
@@ -1747,7 +1747,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-075.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-075.json",
@@ -1758,7 +1758,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-076.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-076.json",
@@ -1769,7 +1769,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-077.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-077.json",
@@ -1780,7 +1780,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-078.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-078.json",
@@ -1791,7 +1791,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-079.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-079.json",
@@ -1802,7 +1802,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-080.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-080.json",
@@ -1813,7 +1813,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-081.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-081.json",
@@ -1824,7 +1824,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-082.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-082.json",
@@ -1835,7 +1835,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-083.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-083.json",
@@ -1846,7 +1846,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-084.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-084.json",
@@ -1857,7 +1857,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-085.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-085.json",
@@ -1868,7 +1868,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Rn-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Rn-002.json",
@@ -1879,7 +1879,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-086.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-086.json",
@@ -1890,7 +1890,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-087.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-087.json",
@@ -1901,7 +1901,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-088.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-088.json",
@@ -1912,7 +1912,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-089.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-089.json",
@@ -1923,7 +1923,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-090.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-090.json",
@@ -1934,7 +1934,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-091.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-091.json",
@@ -1945,7 +1945,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-092.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-092.json",
@@ -1956,7 +1956,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-093.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-093.json",
@@ -1967,7 +1967,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-094.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-094.json",
@@ -1978,7 +1978,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-095.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-095.json",
@@ -1989,7 +1989,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-096.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-096.json",
@@ -2000,7 +2000,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-097.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-097.json",
@@ -2011,7 +2011,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-098.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-098.json",
@@ -2022,7 +2022,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-099.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-099.json",
@@ -2033,7 +2033,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-100.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-100.json",
@@ -2044,7 +2044,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-101.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-101.json",
@@ -2055,7 +2055,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-102.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-102.json",
@@ -2066,7 +2066,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-103.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-103.json",
@@ -2077,7 +2077,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-104.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-104.json",
@@ -2088,7 +2088,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-105.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-105.json",
@@ -2099,7 +2099,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-106.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-106.json",
@@ -2110,7 +2110,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-107.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-107.json",
@@ -2121,7 +2121,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-108.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-108.json",
@@ -2132,7 +2132,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-109.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-109.json",
@@ -2143,7 +2143,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-110.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-110.json",
@@ -2154,7 +2154,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-111.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-111.json",
@@ -2165,7 +2165,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-112.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-112.json",
@@ -2176,7 +2176,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Ar-001.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ar-001.json",
@@ -2187,7 +2187,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Ar-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ar-002.json",
@@ -2198,7 +2198,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-001.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-001.json",
@@ -2209,7 +2209,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-002.json",
@@ -2220,7 +2220,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-003.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-003.json",
@@ -2231,7 +2231,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-004.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-004.json",
@@ -2242,7 +2242,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-005.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-005.json",
@@ -2253,7 +2253,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-006.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-006.json",
@@ -2264,7 +2264,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-007.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-007.json",
@@ -2275,7 +2275,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-008.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-008.json",
@@ -2286,7 +2286,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-009.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-009.json",
@@ -2297,7 +2297,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-010.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-010.json",
@@ -2308,7 +2308,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-011.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-011.json",
@@ -2319,7 +2319,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-012.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-012.json",
@@ -2330,7 +2330,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-013.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-013.json",
@@ -2341,7 +2341,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-014.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-014.json",
@@ -2352,7 +2352,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-015.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-015.json",
@@ -2363,7 +2363,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-016.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-016.json",
@@ -2374,7 +2374,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-017.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-017.json",
@@ -2385,7 +2385,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-018.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-018.json",
@@ -2396,7 +2396,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-019.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-019.json",
@@ -2407,7 +2407,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-020.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-020.json",
@@ -2418,7 +2418,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-021.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-021.json",
@@ -2429,7 +2429,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-022.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-022.json",
@@ -2440,7 +2440,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-023.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-023.json",
@@ -2451,7 +2451,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-024.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-024.json",
@@ -2462,7 +2462,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-025.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-025.json",
@@ -2473,7 +2473,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-026.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-026.json",
@@ -2484,7 +2484,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-027.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-027.json",
@@ -2495,7 +2495,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-028.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-028.json",
@@ -2506,7 +2506,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-029.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-029.json",
@@ -2517,7 +2517,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-030.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-030.json",
@@ -2528,7 +2528,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-031.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-031.json",
@@ -2539,7 +2539,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-032.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-032.json",
@@ -2550,7 +2550,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-033.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-033.json",
@@ -2561,7 +2561,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-034.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-034.json",
@@ -2572,7 +2572,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-035.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-035.json",
@@ -2583,7 +2583,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-036.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-036.json",
@@ -2594,7 +2594,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-037.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-037.json",
@@ -2605,7 +2605,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-038.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-038.json",
@@ -2616,7 +2616,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-039.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-039.json",
@@ -2627,7 +2627,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-040.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-040.json",
@@ -2638,7 +2638,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-041.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-041.json",
@@ -2649,7 +2649,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-042.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-042.json",
@@ -2660,7 +2660,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-043.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-043.json",
@@ -2671,7 +2671,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-044.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-044.json",
@@ -2682,7 +2682,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-045.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-045.json",
@@ -2693,7 +2693,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-046.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-046.json",
@@ -2704,7 +2704,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-047.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-047.json",
@@ -2715,7 +2715,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-048.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-048.json",
@@ -2726,7 +2726,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-049.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-049.json",
@@ -2737,7 +2737,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-050.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-050.json",
@@ -2748,7 +2748,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-051.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-051.json",
@@ -2759,7 +2759,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-052.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-052.json",
@@ -2770,7 +2770,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-053.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-053.json",
@@ -2781,7 +2781,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-054.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-054.json",
@@ -2792,7 +2792,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-055.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-055.json",
@@ -2803,7 +2803,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-056.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-056.json",
@@ -2814,7 +2814,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-057.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-057.json",
@@ -2825,7 +2825,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-058.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-058.json",
@@ -2836,7 +2836,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-059.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-059.json",
@@ -2847,7 +2847,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-060.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-060.json",
@@ -2858,7 +2858,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-061.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-061.json",
@@ -2869,7 +2869,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-062.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-062.json",
@@ -2880,7 +2880,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-063.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-063.json",
@@ -2891,7 +2891,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-064.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-064.json",
@@ -2902,7 +2902,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-065.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-065.json",
@@ -2913,7 +2913,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-066.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-066.json",
@@ -2924,7 +2924,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-067.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-067.json",
@@ -2935,7 +2935,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-068.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-068.json",
@@ -2946,7 +2946,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-069.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-069.json",
@@ -2957,7 +2957,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-070.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-070.json",
@@ -2968,7 +2968,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-071.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-071.json",
@@ -2979,7 +2979,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-072.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-072.json",
@@ -2990,7 +2990,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-073.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-073.json",
@@ -3001,7 +3001,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-074.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-074.json",
@@ -3012,7 +3012,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-075.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-075.json",
@@ -3023,7 +3023,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-076.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-076.json",
@@ -3034,7 +3034,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-077.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-077.json",
@@ -3045,7 +3045,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-078.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-078.json",
@@ -3056,7 +3056,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-079.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-079.json",
@@ -3067,7 +3067,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-080.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-080.json",
@@ -3078,7 +3078,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-081.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-081.json",
@@ -3089,7 +3089,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-082.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-082.json",
@@ -3100,7 +3100,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-083.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-083.json",
@@ -3111,7 +3111,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-084.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-084.json",
@@ -3122,7 +3122,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-085.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-085.json",
@@ -3133,7 +3133,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-086.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-086.json",
@@ -3144,7 +3144,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-087.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-087.json",
@@ -3155,7 +3155,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-088.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-088.json",
@@ -3166,7 +3166,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-089.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-089.json",
@@ -3177,7 +3177,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-090.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-090.json",
@@ -3188,7 +3188,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-091.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-091.json",
@@ -3199,7 +3199,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-092.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-092.json",
@@ -3210,7 +3210,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-093.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-093.json",
@@ -3221,7 +3221,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-094.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-094.json",
@@ -3232,7 +3232,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-095.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-095.json",
@@ -3243,7 +3243,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-096.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-096.json",
@@ -3254,7 +3254,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-097.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-097.json",
@@ -3265,7 +3265,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-098.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-098.json",
@@ -3276,7 +3276,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-099.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-099.json",
@@ -3287,7 +3287,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-100.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-100.json",
@@ -3298,7 +3298,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_B-140.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-140.json",
@@ -3309,7 +3309,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Ba-001.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ba-001.json",
@@ -3320,7 +3320,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Ba-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ba-002.json",
@@ -3331,7 +3331,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Ba-003.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ba-003.json",
@@ -3342,7 +3342,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-004.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-004.json",
@@ -3353,7 +3353,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-005.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-005.json",
@@ -3364,7 +3364,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-006.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-006.json",
@@ -3375,7 +3375,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-007.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-007.json",
@@ -3386,7 +3386,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-008.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-008.json",
@@ -3397,7 +3397,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-009.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-009.json",
@@ -3408,7 +3408,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-010.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-010.json",
@@ -3419,7 +3419,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-011.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-011.json",
@@ -3430,7 +3430,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-012.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-012.json",
@@ -3441,7 +3441,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-013.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-013.json",
@@ -3452,7 +3452,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-014.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-014.json",
@@ -3463,7 +3463,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-015.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-015.json",
@@ -3474,7 +3474,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-016.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-016.json",
@@ -3485,7 +3485,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-017.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-017.json",
@@ -3496,7 +3496,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-018.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-018.json",
@@ -3507,7 +3507,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-019.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-019.json",
@@ -3518,7 +3518,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-020.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-020.json",
@@ -3529,7 +3529,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-021.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-021.json",
@@ -3540,7 +3540,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-022.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-022.json",
@@ -3551,7 +3551,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-023.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-023.json",
@@ -3562,7 +3562,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-024.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-024.json",
@@ -3573,7 +3573,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-025.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-025.json",
@@ -3584,7 +3584,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-026.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-026.json",
@@ -3595,7 +3595,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-027.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-027.json",
@@ -3606,7 +3606,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-028.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-028.json",
@@ -3617,7 +3617,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-029.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-029.json",
@@ -3628,7 +3628,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-030.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-030.json",
@@ -3639,7 +3639,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-031.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-031.json",
@@ -3650,7 +3650,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-032.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-032.json",
@@ -3661,7 +3661,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-033.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-033.json",
@@ -3672,7 +3672,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-034.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-034.json",
@@ -3683,7 +3683,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-035.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-035.json",
@@ -3694,7 +3694,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-036.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-036.json",
@@ -3705,7 +3705,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-037.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-037.json",
@@ -3716,7 +3716,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-038.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-038.json",
@@ -3727,7 +3727,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-039.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-039.json",
@@ -3738,7 +3738,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-040.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-040.json",
@@ -3749,7 +3749,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-041.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-041.json",
@@ -3760,7 +3760,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-042.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-042.json",
@@ -3771,7 +3771,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-043.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-043.json",
@@ -3782,7 +3782,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-044.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-044.json",
@@ -3793,7 +3793,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-045.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-045.json",
@@ -3804,7 +3804,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-046.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-046.json",
@@ -3815,7 +3815,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-047.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-047.json",
@@ -3826,7 +3826,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-048.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-048.json",
@@ -3837,7 +3837,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-049.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-049.json",
@@ -3848,7 +3848,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-050.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-050.json",
@@ -3859,7 +3859,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-051.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-051.json",
@@ -3870,7 +3870,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-052.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-052.json",
@@ -3881,7 +3881,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-053.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-053.json",
@@ -3892,7 +3892,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-054.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-054.json",
@@ -3903,7 +3903,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-055.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-055.json",
@@ -3914,7 +3914,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-056.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-056.json",
@@ -3925,7 +3925,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-057.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-057.json",
@@ -3936,7 +3936,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-058.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-058.json",
@@ -3947,7 +3947,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-059.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-059.json",
@@ -3958,7 +3958,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-060.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-060.json",
@@ -3969,7 +3969,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-061.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-061.json",

--- a/model/nerdm-context.jsonld
+++ b/model/nerdm-context.jsonld
@@ -12,11 +12,11 @@
         "skos": "http://www.w3.org/2004/02/skos/core#",
         "pod": "https://project-open-data.cio.gov/v1.1/schema#",
         "rmmperson": "https://nist.org/od/dm/person/",
-        "nrd": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#",
-        "nrdp": "https://www.nist.gov/od/dm/nerdm-pub-schema/v0.1#"
+        "nrd": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#",
+        "nrdp": "https://data.nist.gov/od/dm/nerdm-pub-schema/v0.1#"
     }
 
-    "@id": "https://www.nist.gov/od/dm/nerdm-context.jsonld",
+    "@id": "https://data.nist.gov/od/dm/nerdm-context.jsonld",
     "title": "The NIST Extended Resource Data model (NERDm) JSON-LD context",
     "description": "This is the base context definition for encoding NERDm metadata in JSON-LD format"
 }

--- a/model/nerdm-pub-schema.json
+++ b/model/nerdm-pub-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$extensionSchemas": ["https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
-    "id": "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#",
+    "$extensionSchemas": ["https://data.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
+    "id": "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#",
     "rev": "wd1",
     "title": "The NERDm extension metadata for Public Data",
     "description": "These classes extend the based NERDm schema to different types of published data",
@@ -13,7 +13,7 @@
                 "This must be convertable to a compliant and complete POD record; thus, this class adds all remaining POD elements missing from the core"
             ],
             "allOf": [
-                { "$ref": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Resource"},
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Resource"},
                 {
                     "type": "object",
                     "properties": {
@@ -184,7 +184,7 @@
         "DataFile": {
             "description": "a description of a downloadable, finite stream of data",
             "allOf": [
-                { "$ref": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
                 {
                     "properties": {
 
@@ -319,7 +319,7 @@
             "properties": {
                 "algorithm": {
                     "description": "the algorithm used to produce the checksum hash",
-                    "$ref": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Topic"
+                    "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Topic"
                 },
                 "hash": {
                     "description": "the checksum value",
@@ -340,7 +340,7 @@
                 "This Component subtype implements hierarchical resources; a subcollection is equivalent to a directory that can contain other components, including other subcollections."
             ],
             "allOf": [
-                { "$ref": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
                 {
                     "properties": {
                         
@@ -393,7 +393,7 @@
                 "This type should not be used to capture a resource's home page as this would be redundant with the landingPage resource property."
             ],
             "allOf": [
-                { "$ref": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
                 {
                     "properties": {
                         "accessURL": {
@@ -435,7 +435,7 @@
                 "When converting an API component to a POD distribution, the output format should set to 'API'."
             ],
             "allOf": [
-                { "$ref": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
                 {
                     "properties": {
                         "accessURL": {
@@ -654,7 +654,7 @@
                     "description": "The institution the person was affiliated with at the time of publication",
                     "type": "array",
                     "items": {
-                        "$ref": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/ResourceReference"
+                        "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/ResourceReference"
                     },
                     "asOntology": {
                         "@context": "profile-schema-onto.json",

--- a/model/nerdm-pub-schema.json
+++ b/model/nerdm-pub-schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$extensionSchemas": ["https://data.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
+    "$extensionSchemas": ["https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
     "id": "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#",
     "rev": "wd1",
     "title": "The NERDm extension metadata for Public Data",

--- a/model/nerdm-schema-context.jsonld
+++ b/model/nerdm-schema-context.jsonld
@@ -11,7 +11,7 @@
         "deo": "http://purl.org/spar/deo/",
         "org": "",
         "pod": "https://project-open-data.cio.gov/v1.1/schema#",
-        "nrd": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#",
+        "nrd": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#",
         "sdpperson": "https://nist.org/od/dm/person/",
 
         "title": "dc:title",
@@ -40,7 +40,7 @@
         "proxyFor": "ore:proxyFor"
     }
 
-    "@id": "https://www.nist.gov/od/dm/nerdm-context.jsonld",
+    "@id": "https://data.nist.gov/od/dm/nerdm-context.jsonld",
     "title": "The core NIST Extended Resource Data model (NERDm) JSON-LD context",
     "description": "This is the base context definition for encoding core NERDm metadata in JSON-LD format"
 }

--- a/model/nerdm-schema.json
+++ b/model/nerdm-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$extensionSchemas": ["https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
-    "id": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#",
+    "$extensionSchemas": ["https://data.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
+    "id": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#",
     "rev": "wd1",
     "title": "The JSON Schema for the NIST Extended Resource Data model (NERDm)",
     "description": "A JSON Schema specfying the core NERDm classes",

--- a/model/nerdm-schema.json
+++ b/model/nerdm-schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$extensionSchemas": ["https://data.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
+    "$extensionSchemas": ["https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
     "id": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#",
     "rev": "wd1",
     "title": "The JSON Schema for the NIST Extended Resource Data model (NERDm)",

--- a/model/pod-schema.json
+++ b/model/pod-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "$extensionSchemas": ["http://mgi.nist.gov/mgi-json-schema/v0.1"],
-    "id": "http://www.nist.gov/dp/di/schema/pod-schema/v1.1#",
+    "id": "http://data.nist.gov/od/dm/pod-schema/v1.1#",
     "title": "US Project Open Data Schema as Extended JSON Schema",
     "description": "This JSON Schema expresses the POD schema (v1.1) so that instances can be validated via a JSON Schema validater",
     "definitions": {
@@ -24,17 +24,17 @@
             "oneOf": [
                 {
                     "description": "a reference to the official POD jsonld file",
-                    "$ref": "/definitions/PODonlyContext"
+                    "$ref": "#/definitions/PODonlyContext"
                 },
                 {
                     "description": "an array the gives both the standard POD context plus additional extension contexts",
                     "type": "array",
                     "items": [
-                        { "$ref": "/definitions/PODonlyContext" }
+                        { "$ref": "#/definitions/PODonlyContext" }
                     ],
                     "additionalItems": {
                         "oneOf": [
-                            { "$ref": "/definitions/URLContext" },
+                            { "$ref": "#/definitions/URLContext" },
                             { "type": "object" }
                         ]
                     }
@@ -96,7 +96,7 @@
                     "notes": [
                         "Dates should be ISO 8601 of highest resolution. In other words, as much of YYYY-MM-DDThh:mm:ss.sTZD as is relevant to this dataset. If there is a need to reflect that the dataset is continually updated, ISO 8601 formatting can account for this with repeating intervals. For instance, R/P1D for daily, R/P2W for every two weeks, and R/PT5M for every five minutes."
                     ],
-                    "$ref": "ISO8601DateRange",
+                    "$ref": "#/definitions/ISO8601DateRange",
                     "asOntology": {
                         "@context": "profile-schema-onto.json",
                         "prefLabel": "Last Update",
@@ -109,7 +109,7 @@
                     "notes": [
                         "This is a container for a publisher object which groups together the fields: name and subOrganization. The subOrganization field can also contain a publisher object which allows one to describe an organization’s hierarchy. Where greater specificity is desired, include as many levels of publisher as is useful, in ascending order, using the below format."
                     ],
-                    "$ref": "/definitions/Organization",
+                    "$ref": "#/definitions/Organization",
                     "asOntology": {
                         "@context": "profile-schema-onto.json",
                         "prefLabel": "Publisher",
@@ -122,7 +122,7 @@
                     "notes": [
                         "This is a container for two fields that together make up the contact information for the dataset. contactPoint should always contain both the person’s appropriately formatted full name (fn) and email (hasEmail)."
                     ],
-                    "$ref": "/definitions/ContactPoint",
+                    "$ref": "#/definitions/ContactPoint",
                     "asOntology": {
                         "@context": "profile-schema-onto.json",
                         "prefLabel": "Contact Name and Email",
@@ -312,7 +312,7 @@
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "distribution.json"
+                                "$ref": "#/definitions/Distribution"
                             },
                             "minItems": 1,
                             "uniqueItems": true
@@ -617,7 +617,7 @@
                 },
                 "subOrganizationOf": {
                     "description": "A parent organizational entity",
-                    "$ref": "/definitions/Organization",
+                    "$ref": "#/definitions/Organization",
                     "asOntology": {
                         "@context": "profile-schema-onto.json",
                         "referenceProperty": "org:subOrganizationOf"

--- a/python/nistoar/rmm/ingest/tests/test_wsgi.py
+++ b/python/nistoar/rmm/ingest/tests/test_wsgi.py
@@ -28,6 +28,7 @@ def setUpModule():
     loghdlr = logging.FileHandler(os.path.join(tmpdir(),"test_wsgi.log"))
     loghdlr.setLevel(logging.INFO)
     rootlog.addHandler(loghdlr)
+    rootlog.setLevel(logging.INFO)
 
 def tearDownModule():
     global loghdlr

--- a/python/nistoar/rmm/ingest/wsgi.py
+++ b/python/nistoar/rmm/ingest/wsgi.py
@@ -63,6 +63,13 @@ class RMMRecordIngestApp(object):
         if authmeth != 'header':
             authmeth = 'qparam'
         self._auth = (authmeth, authkey)
+        if authkey:
+            if authmeth == 'header':
+                log.info("Authorization key is required of clients via HTTP Header")
+            else:
+                log.info("Authorization key is required of clients via query parameter")
+        else:
+            log.warn("No authorization key required of clients")
         
 
     def handle_request(self, env, start_resp):

--- a/python/nistoar/rmm/mongo/nerdm.py
+++ b/python/nistoar/rmm/mongo/nerdm.py
@@ -7,7 +7,7 @@ from .loader import (Loader, RecordIngestError, JSONEncodingError,
                      UpdateWarning, LoadLog)
 from .loader import ValidationError, SchemaError, RefResolutionError
 
-DEF_BASE_SCHEMA = "https://www.nist.gov/od/dm/nerdm-schema/v0.1#"
+DEF_BASE_SCHEMA = "https://data.nist.gov/od/dm/nerdm-schema/v0.1#"
 DEF_SCHEMA = DEF_BASE_SCHEMA + "/definitions/Resource"
 
 COLLECTION_NAME="record"


### PR DESCRIPTION
This PR provides various bug fixes and enhancements that support the preservation and ingest services.  In particular, this includes:
* updates to pod2nerdm.jq that detect hierarchical collections and multi-paragraph descriptions
* updates schema and context identifiers for their locations on the production systems (at data.nist.gov)
* bug fix: detect when downloadURLs point to testdata.nist.gov as an indication to support hierarchical filepaths
* log the authentication mechanism used

These have already been tested on oardev.  