### PR TITLE
ODD-582: Switch ingest service to pull config data from service

### DIFF
--- a/python/nistoar/rmm/config.py
+++ b/python/nistoar/rmm/config.py
@@ -2,7 +2,7 @@
 Utilities for obtaining a configuration for RMM services
 """
 from __future__ import print_function
-import os, sys, logging, json, yaml, re, collections
+import os, sys, logging, json, yaml, re, collections, time
 from urlparse import urlparse, urlunparse
 import requests
 

--- a/python/nistoar/rmm/config.py
+++ b/python/nistoar/rmm/config.py
@@ -1,7 +1,8 @@
 """
-Utilities for obtaining a configuration for a service
+Utilities for obtaining a configuration for RMM services
 """
-import os, sys, logging, json, yaml, re
+from __future__ import print_function
+import os, sys, logging, json, yaml, re, collections
 from urlparse import urlparse, urlunparse
 import requests
 
@@ -118,7 +119,7 @@ def load_from_url(configurl):
         out = data
         if 'propertySources' in data:
             # this data is from the configuration server
-            out = _extract_config_from_csdata(data)
+            out = ConfigService.extract(data, flat=True)
             
         return out
             
@@ -128,28 +129,6 @@ def load_from_url(configurl):
     except requests.RequestException, ex:
         raise ConfigurationException("Failed to pull configuration from URL: " +
                                      str(ex), cause=ex)
-
-def _extract_config_from_csdata(data):
-    """
-    return configuration data used by applications given a response from the
-    configuration server.  See the configuration server documentation for 
-    details regarding for format and interpretation of the config server 
-    response.  
-    """
-    try:
-
-        out = data['propertySources'][-1]['source']
-        if len(data['propertySources']) > 1:
-            out.update( data['propertySources'][0]['source'] )
-        return out
-
-    except KeyError, ex:
-        raise ConfigurationException("Unexpected format from config server; " +
-                                     "property not found: " + str(ex), cause=ex)
-    except IndexError, ex:
-        raise ConfigurationException("Unexpected format from config server; " +
-                                     "empty propertySource (no item "+str(ex)+
-                                     ").", cause=ex)
 
 
 LOG_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
@@ -209,3 +188,236 @@ def configure_log(logfile=None, level=None, format=None, config=None,
         rootlogger.error("FYI: Writing log messages to %s",logfile)
         
 
+class ConfigService(object):
+    """
+    an interface to the configuration service
+    """
+
+    def __init__(self, urlbase, envprof=None):
+        """
+        initialize the service.
+        :param urlbase str:  the base URL for the service which must include 
+                             the scheme (either http: or https:), the server,
+                             and the base path.  It can also include a port
+                             number.
+        :param envprof str:  the label indicating the default environment 
+                             profile (usually, one of 'local', 'dev', 'test',
+                             or 'prod').
+        """
+        self._base = urlbase
+        self._prof = envprof
+        if not self._base.endswith('/'):
+            self._base += '/'
+
+        u = urlparse(self._base)
+        msg = "Insufficient config service URL: "+self._base+" ({0})"
+        if not u.scheme:
+            raise ConfigurationException(msg.format("missing http/https"))
+        if not u.netloc:
+            raise ConfigurationException(msg.format("missing server name"))
+
+    def url_for(self, component, envprof=None):
+        """
+        return the proper URL for access the configuration for a given 
+        component.  
+        :param component   the name for the service or component that 
+                              configuration data is desired for
+        :param envprof     the desired version of the configuration given 
+                              its environment/profile name.  If not provided,
+                              the profile set at construction time will 
+                              be assumed.
+        """
+        if not envprof:
+            envprof = self._prof
+        if envprof:
+            component = '/'.join([component, envprof])
+        
+        return self._base + component
+
+    def is_up(self):
+        """
+        return true if the service appears to be up.  
+        """
+        try:
+            resp = requests.get(self.url_for("ready"))
+            return resp.status_code and resp.status_code < 500
+        except requests.exceptions.RequestException:
+            return False
+
+    def wait_until_up(self, timeout=10, rais=True, verboseout=None):
+        """
+        poll the service until responds.  
+        :param timeout int:  the maximum number of seconds to wait before 
+                             timing out.
+        :param rais bool:    if True, raise a ConfifigurationException if
+                             the timeout period is reached without a response 
+                             from the service.
+        :param verboseout file:  a file stream to send message about waiting;
+                             if None, no messages are printed.
+        :return bool:  True if the service is detected as up; False, if the 
+                       timeout period is exceeded (unless rais=True).
+        :raises ConfifigurationException: if rais=True and the timeout period
+                       is exceeded without getting a response from the service.
+        """
+        start = time.time()
+        if self.is_up():
+            if verboseout:
+                print("RMM: configuration service is ready", file=verboseout)
+            return True
+        if verboseout:
+            print("RMM: Waiting for configuration service...", file=verboseout)
+
+        updated = start
+        while time.time()-start < timeout:
+            if verboseout and time.time()-updated > 10:
+                print("RMM: ...waiting...")
+                updated = time.time()
+                
+            time.sleep(2)
+            
+            if self.is_up():
+                if verboseout:
+                    print("RMM: ...ready", file=verboseout)
+                return True
+
+        if verboseout:
+            print("RMM: ...timed out!")        
+        if rais:
+            raise ConfigurationException("Waiting for configuration service "+
+                                         "timed out")
+        return False
+        
+
+    def get(self, component, envprof=None, flat=False):
+        """
+        retrieve the configuration for the service or component with the 
+        given name.  Internally, this will transform the raw output from 
+        the service into a configuration ready to give to the PDR component
+        (including combining the profile specializations with default values).
+
+        :param component str: the name for the service or component that 
+                              configuration data is desired for
+        :param envprof   str: the desired version of the configuration given 
+                              its environment/profile name.  If not provided,
+                              the profile set at construction time will 
+                              be assumed.
+        :param flat     bool: if true, keep the flat structure provided directly
+                              by the config server.
+        :return dict:  the parsed configuration data 
+        """
+        try:
+            resp = requests.get(self.url_for(component, envprof))
+            resp.raise_for_status()
+            return self._extract(resp.json(), component, flat)
+        except ValueError as ex:
+            raise ConfigurationException("Config service response: "+str(ex))
+        except requests.exceptions.RequestException as ex:
+            raise ConfigurationException("Failed to access configuration for "+
+                                         component + ": " + str(ex))
+
+    def _extract(self, rawdata, comp="unknown", flat=False):
+        return self.__class__.extract(rawdata, comp, flat)
+
+    @classmethod
+    def _deep_update(cls, defdict, upddict):
+        for k, v in upddict.iteritems():
+            if isinstance(v, collections.Mapping):
+                defdict[k] = cls._deep_update(defdict.get(k, v.__class__()), v)
+            else:
+                defdict[k] = v
+        return defdict
+
+    _idxre = re.compile(r'\[(\d+)\]')
+    @classmethod
+    def _inflate(cls, flat):
+        out = flat.__class__()
+        for key in flat:
+            levs = cls._idxre.sub(r'.\g<0>', key)
+            levs = levs.split('.')
+            pv = out
+            while levs:
+                lev = levs.pop(0)
+                if len(levs) == 0: 
+                    pv[lev] = flat[key]
+                else:
+                    if not isinstance(pv.get(lev), collections.Mapping):
+                        pv[lev] = flat.__class__()
+                    pv = pv[lev]
+
+        return cls._cvtarrays(out)
+
+    @classmethod
+    def _cvtarrays(cls, md):
+        if not isinstance(md, collections.Mapping):
+            return md
+        
+        keys = md.keys()
+        m = [cls._idxre.match(k) for k in keys]
+        if all(m):
+            ary = [( int(m[i].group(1)), md[keys[i]] ) for i in range(len(m))]
+            ary.sort(lambda x,y: cmp(x[0], y[0]))
+            return [ cls._cvtarrays(el[1]) for el in ary ]
+        else:
+            for k in keys:
+                md[k] = cls._cvtarrays(md[k])
+            return md
+
+    @classmethod
+    def extract(cls, rawdata, comp="unknown", flat=False):
+        """
+        extract component configuration from the config service response.
+        This includes combining the environment/profile-specific data
+        with the defaults.  
+        """
+        try:
+            name = rawdata.get('name') or comp 
+            vers = rawdata['propertySources']
+        except KeyError, ex:
+            raise ConfigurationException("Missing config param for label="+name+
+                                         ": "+str(ex))
+        if not isinstance(vers, list):
+            raise ConfigurationException("Bad data schema for label="+name+
+                                      ": wrong type for propertySources: "+
+                                      str(type(vers)))
+        if len(vers) == 0:
+            raise ConfigurationException(name+": config data for app name not "+
+                                         "found")
+
+        try:
+            out = vers[-1]['source']
+            out.update(vers[0]['source'])
+            if not flat:
+                out = cls._inflate(out)
+        except TypeError as ex:
+            raise ConfigurationException("Bad data schema for label="+name+
+                                         ": wrong type for propertySources "+
+                                         "item: "+ str(type(vers)))
+        except KeyError as ex:
+            raise ConfigurationException("Bad data schema for label="+name+
+                                         ": missing property: "+str(ex))
+
+        return out
+
+    @classmethod
+    def from_env(cls):
+        """
+        return an instance of ConfigService based on environment variables
+        or None if the proper environment is not set up.  To return an instance,
+        the OAR_CONFIG_SERVICE environment variable needs to contain the 
+        service's base URL.  If OAR_CONFIG_ENV is set, it will be taken as 
+        the environment/platform label.  
+
+        :raise ConfigurationException: if base URL in OAR_CONFIGSERVICE is 
+                                       malformed.
+        """
+        if 'OAR_CONFIG_SERVICE' in os.environ:
+            prof = os.environ.get('OAR_CONFIG_ENV')
+            return ConfigService(os.environ['OAR_CONFIG_SERVICE'], prof)
+        return None
+
+service = None
+try:
+    service = ConfigService.from_env()
+except:
+    pass
+        

--- a/python/nistoar/rmm/tests/data/csconfig.json
+++ b/python/nistoar/rmm/tests/data/csconfig.json
@@ -10,9 +10,7 @@
                 "oar.mongodb.port": "3333",
                 "oar.mongodb.host": "mongoinit",
                 "oar.mongodb.database.name": "TestDB",
-                "stuff": {
-                    "filter": "off"
-                }
+                "stuff.filter": "off"
             }
         },
         {
@@ -20,10 +18,8 @@
             "source": {
                 "oar.mongodb.database.name": "ProdDB",
                 "name": "Hank",
-                "stuff": {
-                    "filter": "on",
-                    "mode": "validate"
-                }
+                "stuff.filter": "on",
+                "stuff.mode": "validate"
             }
         }
     ]

--- a/python/nistoar/rmm/tests/test_config.py
+++ b/python/nistoar/rmm/tests/test_config.py
@@ -51,15 +51,15 @@ class TestConfig(test.TestCase):
         with open(cfgfile) as fd:
             csdata = json.load(fd)
 
-        cfg = config._extract_config_from_csdata(csdata)
-        names = "oar.mongodb.port oar.mongodb.host oar.mongodb.database.name stuff name".split()
+        cfg = config.ConfigService.extract(csdata, flat=True)
+        names = "oar.mongodb.port oar.mongodb.host oar.mongodb.database.name stuff.filter stuff.mode name".split()
         for name in names:
             self.assertIn(name, cfg)
         self.assertEqual(len(cfg.keys()), len(names))
         self.assertEqual(cfg['oar.mongodb.database.name'], "TestDB")
         self.assertEqual(cfg['oar.mongodb.port'], "3333")
         self.assertEqual(cfg['name'], "Hank")
-        self.assertEqual(cfg['stuff'], { "filter": "off" })
+        self.assertEqual(cfg['stuff.filter'], "off")
 
     @test.skipIf(not os.environ.get('CONFIG_SERVER_URL'),
                  "test config server not available")

--- a/scripts/ingest-uwsgi.py
+++ b/scripts/ingest-uwsgi.py
@@ -56,7 +56,7 @@ if not cfg:
     confsrvc = get_confservice()
     if confsrvc:
         appname = uwsgi.opt.get('oar_config_appname',
-                                os.environ.get('OAR_CONFIG_APP'))
+                                os.environ.get('OAR_CONFIG_APP', 'rmm-ingest'))
         cfg = confsrvc.get(appname)
 
 if not cfg:

--- a/scripts/ingest-uwsgi.py
+++ b/scripts/ingest-uwsgi.py
@@ -26,21 +26,42 @@ from nistoar.rmm import config
 from nistoar.rmm.exceptions import ConfigurationException
 from nistoar.rmm.ingest import wsgi
 
-# get configuration
-confserv = uwsgi.opt.get('oar_config_baseurl',
-                         os.environ.get('OAR_CONFIGSERVER'))
-confenv = uwsgi.opt.get('oar_config_env',
-                         os.environ.get('OAR_CONFIG_ENV'))
+confsrvc = None
+def get_confservice():
+    cfgsrvc = None
+    if 'oar_config_service' in uwsgi.opt:
+        # this service is based on uwsgi command-line inputs
+        cfgsrvc = config.ConfigService(uwsgi.opt.get('oar_config_service'),
+                                        uwsgi.opt.get('oar_config_env'))
+        timeout = int(uwsgi.opt.get('oar_config_timeout', 10))
+                               
+    else:
+        # this service is based on environment variables
+        cfgsrvc = config.service
+        timeout = int(os.environ.get('OAR_CONFIG_TIMEOUT', 10))
+
+    cfgsrvc.wait_until_up(timeout, True, sys.stderr)
+    return cfgsrvc
+
+
+# determine where the configuration is coming from.  Check first to see
+# files were provided via the uwsgi command line.
+cfg = None
 confsrc = uwsgi.opt.get("oar_config_file")
 if confsrc:
-    confsrc = "file:" + confsrc
-else:
-    confsrc = uwsgi.opt.get('oar_config_loc', 'rmm-ingest-service')
-    if confenv:
-        confsrc += '/'+confenv
-if not confsrc:
-    raise RuntimeError("ingester: nist-oar configuration not provided")
-cfg = config.resolve_configuration(confsrc, confserv)
+    cfg = config.resolve_configuration("file:" + confsrc)
+
+if not cfg:
+    # get the configuration from the config service
+    confsrvc = get_confservice()
+    if confsrvc:
+        appname = uwsgi.opt.get('oar_config_appname',
+                                os.environ.get('OAR_CONFIG_APP'))
+        cfg = confsrvc.get(appname)
+
+if not cfg:
+    raise ConfigurationException("ingester: nist-oar configuration not "+
+                                 "provided")
 
 # set up logging
 if 'logfile' not in cfg:
@@ -57,10 +78,21 @@ if cfg.get('db_authn') and \
    (not cfg['db_authn'].get('user') or not cfg['db_authn'].get('pass')):
     acfg = cfg['db_authn']
     try:
-        rmmconfsrc = acfg.get('rmm_config_loc', 'oar-rmm')
-        if confenv:
-            rmmconfsrc += '/'+confenv
-        rmmcfg = config.resolve_configuration(rmmconfsrc, confserv)
+        rmmcfg = None
+        rmmconfsrc = uwsgi.opt.get("oar_rmm_config_file",
+                                   acfg.get("rmm_config_file"))
+        if rmmconfsrc:
+            rmmcfg = config.resolve_configuration(rmmconfsrc)
+
+        if not rmmcfg:
+            if not confsrvc:
+                convsrvc = get_confservice()
+            if not confsrvc:
+                raise ConfigurationException("ingester: configuration not "+
+                                     "available; set db_authn.rmm_config_file")
+            rmmcfg = confsrvc.get(acfg.get('rmm_config_loc', 'oar-rmm'),
+                                  flat=True)
+
         acfg['user'] = rmmcfg['oar.mongodb.readwrite.user']
         acfg['pass'] = rmmcfg['oar.mongodb.readwrite.password']
 


### PR DESCRIPTION
This PR addresses [ODD-582 ("Switch PDR mdserver and preserver services to get configuration from config server")](http://mml.nist.gov:8080/browse/ODD-582) which observes that currently the metadata and preservation services have been reading their configurations from flat files in their respective containers.  This was true for the ingest service, as well.  In this PR, all three services have been converted to retrieve their configurations from the configuration service, a change that required changes to four repositories.  

This repository contains the ingest service.  The implementation has been adapted from the changes for the metadata and preservation services (see the oar-pdr PR).  It is recommended that these changes be tested via corresponding oar-docker PR.