### PR TITLE
ODD-587: oar-apps operations: enable "resume" start-up mode

### DIFF
--- a/docker/mdtests/ingest_conf.yml
+++ b/docker/mdtests/ingest_conf.yml
@@ -1,3 +1,4 @@
 db_url: "mongodb://localhost/testdb"
 nerdm_schema_dir: /dev/oar-metadata/model
 logfile: /dev/oar-metadata/docker/_docker_ingest.log
+archive_dir: /dev/oar-metadata/docker/_docker_ingest_archive

--- a/docker/mdtests/mdtests.sh
+++ b/docker/mdtests/mdtests.sh
@@ -1,6 +1,12 @@
 #! /bin/bash
 #
 function launch_uwsgi {
+    [ \! -e docker/_docker_uwsgi.log ] || rm docker/_docker_uwsgi.log
+    [ \! -e docker/_docker_ingest.log ] || rm docker/_docker_ingest.log
+    [ \! -e docker/_docker_ingest_archive ] || \
+        rm -rf docker/_docker_ingest_archive
+    mkdir docker/_docker_ingest_archive
+    
     echo starting uwsgi...
     uwsgi --daemonize docker/_docker_uwsgi.log --plugin python    \
           --http-socket :9090 --wsgi-file scripts/ingest-uwsgi.py \


### PR DESCRIPTION
This PR addresses [ODD-587 ("oar-apps operations: enable 'resume' start-up mode")](http://mml.nist.gov:8080/browse/ODD-587) which discusses the need to be able to restart the `apps` application (the public side of the SDP and PDR) in a "resume" mode.  This means that it cleanly and robustly restarts in the state it was in when it last went down.  In particular, the SDP should remember all of the new records that have been ingested via the ingestservice. 

This PR is part of a combination with [`oar-docker` PR 97](https://github.com/usnistgov/oar-docker/pull/97) and [`oar-config` PR 37](https://github.com/usnistgov/oar-config/pull/37).  This PR on `oar-metadata` updates the ingest service: it now archives incoming records to disk in case they need to be reloaded into the RMM.