### PR TITLE
ODD-604:  parse out collection number from s3 download URLs

### DIFF
--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -151,8 +151,8 @@ def filepath:
     if test("https?://s3.amazonaws.com/nist-srd/\\w+/") then
        sub("https?://s3.amazonaws.com/nist-srd/\\w+/"; "")
     else
-      if test("https?://s3.amazonaws.com/nist-\\w+/") then
-         sub("https?://s3.amazonaws.com/nist-\\w+/"; "")
+      if test("https?://s3.amazonaws.com/nist-\\w+/\\w+/") then
+         sub("https?://s3.amazonaws.com/nist-\\w+/\\w+/"; "")
       else
         if test("https?://opendata.nist.gov/\\w+/") then
            sub("https?://opendata.nist.gov/\\w+/"; "")


### PR DESCRIPTION
This PR supports ODD-604 ("PDR-publish misses external distributions") in which the internal PDR metadata service was not capturing distributions with external download URLs, particularly those with s3 URLs.  Properly supporting these distribution required a fix to the stylesheet for converting POD to NERDm: when the URL matches the s3 download pattern, the sheet now properly filters out the collection number.  
