### PR TITLE
ODD-611: Supported checksum files as downloadable files

### DIFF
--- a/etc/merge/dev/nerdm-pub-schema.json
+++ b/etc/merge/dev/nerdm-pub-schema.json
@@ -293,6 +293,25 @@
                 { "$ref": "#/definitions/DownloadableFile" },
                 {
                     "properties": {
+                        "algorithm": {
+                            "description": "the algorithm used to produce the checksum hash",
+                            "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Topic"
+                        },
+                        
+                        "valid": {
+                            "type": "boolean",
+                            "description": "A flag, if True, indicating the the hash value contained in this ChecksumFile is confirmed to be correct for its associated data file."
+                        }
+                        
+                        "describes": {
+                            "type": "string",
+                            "format": "uri-reference"
+                            "asOntology": {
+                                "@context": "profile-schema-onto.json",
+                                "prefLabel": "Checksum for",
+                                "referenceProperty": "ov:describes"
+                            }
+                        }
                     }
                 }
             ]

--- a/etc/merge/dev/nerdm-pub-schema.json
+++ b/etc/merge/dev/nerdm-pub-schema.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$extensionSchemas": ["https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
-    "id": "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#",
-    "rev": "wd1",
+    "$extensionSchemas": ["https://data.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
+    "id": "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#",
+    "rev": "wd2",
     "title": "The NERDm extension metadata for Public Data",
     "description": "These classes extend the based NERDm schema to different types of published data",
     "definitions": {
@@ -13,7 +13,7 @@
                 "This must be convertable to a compliant and complete POD record; thus, this class adds all remaining POD elements missing from the core"
             ],
             "allOf": [
-                { "$ref": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Resource"},
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Resource"},
                 {
                     "type": "object",
                     "properties": {
@@ -145,10 +145,10 @@
             ]
         },
 
-        "DataFile": {
+        "DownloadableFile": {
             "description": "a description of a downloadable, finite stream of data",
             "allOf": [
-                { "$ref": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
                 {
                     "properties": {
 
@@ -205,6 +205,46 @@
                             }
                         },
                 
+                        "checksum": {
+                            "title": "Checksum",
+                            "description": "a checksum for the file",
+                            "$ref": "#/definitions/Checksum"
+                        },
+
+                        "size": {
+                            "description": "the size of the file in bytes",
+                            "type": "integer",
+                            "asOntology": {
+                                "@context": "profile-schema-onto.json",
+                                "prefLabel": "file size",
+                                "referenceProperty": "schema:fileSize"
+                            }
+                        }
+                        
+                    },
+                    "required": [ "filepath" ],
+
+                    "dependencies": {
+                        "downloadURL": {
+                            "properties": {
+                                "mediaType": {
+                                    "type": "string",
+                                    "pattern": "^[-\\w]+/[-\\w]+(\\.[-\\w]+)*([+][-\\w]+)?$"
+                                }
+                            },
+                            "required": [ "mediaType" ]
+                        }
+                    }
+                }
+            ]
+        },
+
+        "DataFile": {
+            "description": "a description of a downloadable file that was provided by the authors (as opposed to a system or checksum file produced by the publication system).",
+            "allOf": [
+                { "$ref": "#/definitions/DownloadableFile" },
+                {
+                    "properties": {
                         "describedBy": {
                             "title": "Data Dictionary",
                             "description": "URL to the data dictionary for the distribution found at the downloadURL",
@@ -242,23 +282,41 @@
                                 "referenceProperty": "pod:describedByType"
                             }
                         }
-                        
-                    },
-                    "required": [ "filepath" ],
-
-                    "dependencies": {
-                        "downloadURL": {
-                            "properties": {
-                                "mediaType": {
-                                    "type": "string",
-                                    "pattern": "^[-\\w]+/[-\\w]+(\\.[-\\w]+)*([+][-\\w]+)?$"
-                                }
-                            },
-                            "required": [ "mediaType" ]
-                        }
                     }
                 }
             ]
+        },
+
+        "ChecksumFile": {
+            "description": "a downloadable file that contains the checksum value for a DataFile.",
+            "allOf": [
+                { "$ref": "#/definitions/DownloadableFile" },
+                {
+                    "properties": {
+                    }
+                }
+            ]
+        },
+
+        "Checksum": {
+            "description": "a checksum with its algorithm noted",
+            "type": "object",
+            "properties": {
+                "algorithm": {
+                    "description": "the algorithm used to produce the checksum hash",
+                    "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Topic"
+                },
+                "hash": {
+                    "description": "the checksum value",
+                    "type": "string",
+                    "asOntology": {
+                        "@context": "profile-schema-onto.json",
+                        "prefLabel": "checksum",
+                        "referenceProperty": "dataid:checksum"
+                    }
+                }
+            },
+            "required": [ "hash" ]
         },
 
         "Subcollection": {
@@ -267,7 +325,7 @@
                 "This Component subtype implements hierarchical resources; a subcollection is equivalent to a directory that can contain other components, including other subcollections."
             ],
             "allOf": [
-                { "$ref": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
                 {
                     "properties": {
                         
@@ -312,6 +370,108 @@
                 "prefLabel": "Subcollection",
                 "referenceProperty": "fedora:Container"
             }
+        },
+
+        "AccessPage": {
+            "description": "a web page that provides indirect access to the resource",
+            "notes": [
+                "This type should not be used to capture a resource's home page as this would be redundant with the landingPage resource property."
+            ],
+            "allOf": [
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
+                {
+                    "properties": {
+                        "accessURL": {
+                            "description": "the URL for accessing this indirect access to the resource",
+                            "type": "string",
+                            "format": "uri"
+                        },
+
+                        "format": {
+                            "title": "Format",
+                            "description": "A human-readable description of the file format of a distribution",
+                            "$ref": "#/definitions/Format",
+                            "asOntology": {
+                                "@context": "profile-schema-onto.json",
+                                "prefLabel": "Format",
+                                "referenceProperty": "dc:format"
+                            }
+                        }
+                    },
+                    "required": [ "accessURL" ]
+                }
+            ]
+        },
+
+        "SearchPage": {
+            "description": "a web page that can be used to search the contents of the resource",
+            "notes": [
+                "Provide this component even if the accessURL is the same as the landing page; this indicates that the landing page provides a search tool in it."
+            ],
+            "allOf": [
+                { "$ref": "#/definitions/AccessPage" }
+            ]
+        },
+
+        "API": {
+            "description": "an application programming interface to the resource",
+            "notes": [
+                "This is typically a web-based interface",
+                "When converting an API component to a POD distribution, the output format should set to 'API'."
+            ],
+            "allOf": [
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
+                {
+                    "properties": {
+                        "accessURL": {
+                            "description": "the URL for accessing this indirect access to the resource",
+                            "type": "string",
+                            "format": "uri"
+                        },
+                
+                        "describedBy": {
+                            "title": "API Description",
+                            "description": "URL to a formal or informal description of the API",
+                            "notes": [
+                                "Use describedByType to help distinguish between formal and informal (i.e. human readable) descriptions."
+                            ],
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "asOntology": {
+                                "@context": "profile-schema-onto.json",
+                                "prefLabel": "Data Dictionary",
+                                "referenceProperty": "http://www.w3.org/2007/05/powder-s#describedby"
+                            }
+                        },
+                        
+                        "describedByType": {
+                            "title": "API Descriptions Type",
+                            "description": "The machine-readable file format (IANA Media Type or MIME Type) of the file’s describedBy URL",
+                            "anyOf": [
+                                {
+                                    "pattern": "^[-\\w]+/[-\\w]+(\\.[-\\w]+)*([+][-\\w]+)?$",
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "asOntology": {
+                                "@context": "profile-schema-onto.json",
+                                "prefLabel": "Data Dictionary Type",
+                                "referenceProperty": "pod:describedByType"
+                            }
+                        }
+                    }
+                }
+            ]
         },
 
         "Format": {
@@ -479,7 +639,7 @@
                     "description": "The institution the person was affiliated with at the time of publication",
                     "type": "array",
                     "items": {
-                        "$ref": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/ResourceReference"
+                        "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/ResourceReference"
                     },
                     "asOntology": {
                         "@context": "profile-schema-onto.json",

--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -196,6 +196,7 @@ def dist2checksum:
     .["@type"] = [ "nrdp:ChecksumFile", "nrdp:DownloadableFile", "dcat:Distribution" ] |
     .["@id"] = (. | componentID("cmps/")) |
     .["_extensionSchemas"] = [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/ChecksumFile" ] |
+    .["mediaType"] = "text/plain" |
     if .format then .format = { description: .format } else . end
 ;
 

--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -89,6 +89,40 @@ def dirname:
     end
 ;
 
+# given a string that looks like a file path, return the unqualified file
+# name.
+#
+# Input: string
+# Output: string
+#
+def basename:
+    sub("/$";"") | 
+    if contains("/") then
+        sub("^.*/"; "")
+    else
+        .
+    end
+;
+
+# remove the filename extension from the input
+#
+# Input: string
+# Output: string
+#
+def remove_extension:
+    if test("\\w\\.") then sub("\\.[^\\.]*$"; "") else . end
+;
+
+# assuming an input file name or path return the filename extension or
+# an empty string if none exists
+#
+# Input: string
+# Output: string
+#
+def extension:
+    if test("\\w\\.") then sub("^.*\\."; "") else "" end
+;
+
 # filter an array of strings, retaining only those that are not in another
 # given input array
 #
@@ -197,6 +231,8 @@ def dist2checksum:
     .["@id"] = (. | componentID("cmps/")) |
     .["_extensionSchemas"] = [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/ChecksumFile" ] |
     .["mediaType"] = "text/plain" |
+    .["algorithm"] = { "@type": "Thing", tag: (.filepath|extension) } |
+    if .description then . else .["description"] = "SHA-256 checksum value for "+(.filepath|basename|remove_extension) end | 
     if .format then .format = { description: .format } else . end
 ;
 

--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -179,9 +179,23 @@ def filepath:
 #
 def dist2download:
     .["filepath"] = ( .downloadURL | filepath ) |
-    .["@type"] = [ "nrdp:DataFile", "dcat:Distribution" ] |
+    .["@type"] = [ "nrdp:DataFile", "nrdp:DownloadableFile", "dcat:Distribution" ] |
     .["@id"] = (. | componentID("cmps/")) |
     .["_extensionSchemas"] = [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile" ] |
+    if .format then .format = { description: .format } else . end
+;
+
+# conversion for a POD-to-NERDm distribution node.  A distribution with a
+# downloadURL and a .sha256 extension gets converted to a ChecksumFile component
+#
+# Input: a Distribution object
+# Output: a Component object with a ChecksumFile type given as @type
+#
+def dist2checksum:
+    .["filepath"] = ( .downloadURL | filepath ) |
+    .["@type"] = [ "nrdp:ChecksumFile", "nrdp:DownloadableFile", "dcat:Distribution" ] |
+    .["@id"] = (. | componentID("cmps/")) |
+    .["_extensionSchemas"] = [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/ChecksumFile" ] |
     if .format then .format = { description: .format } else . end
 ;
 
@@ -231,7 +245,11 @@ def dist2accesspage:
 #
 def dist2comp: 
     if .downloadURL then
-        dist2download
+        if (.downloadURL | endswith(".sha256")) then
+            dist2checksum
+        else
+            dist2download
+        end
     else if .accessURL then
         if (.accessURL | test("doi.org")) then
           dist2hidden

--- a/jq/tests/test_pod2nerdm.jqt
+++ b/jq/tests/test_pod2nerdm.jqt
@@ -104,11 +104,50 @@ include "pod2nerdm"; dirname
 ""
 
 #---------------
-# testing remove elements
+# testing basename()
 #
-include "pod2nerdm"; remove_elements(["a", "a/b/c", "foo"])
-["a", "a/b", "a/b/c", "bar"]
-["a/b", "bar"]
+include "pod2nerdm"; basename
+"plainfile"
+"plainfile"
+
+include "pod2nerdm"; basename
+"foo/bar/now/plainfile"
+"plainfile"
+
+include "pod2nerdm"; basename
+"foo/plainfile"
+"plainfile"
+
+include "pod2nerdm"; basename
+"foo/plainfile/"
+"plainfile"
+
+include "pod2nerdm"; basename
+"foo/"
+"foo"
+
+include "pod2nerdm"; basename
+""
+""
+
+include "pod2nerdm"; basename
+"/"
+""
+
+#---------------
+# testing remove_extension
+#
+include "pod2nerdm"; [.[]|remove_extension]
+["a", "a.JPG", "a.b", "a.b.c", "trial3/trial3a.json.sha256", "trial3/trial3a.json", ".cshrc"]
+["a", "a", "a", "a.b", "trial3/trial3a.json", "trial3/trial3a", ".cshrc"]
+
+
+#---------------
+# testing extension
+#
+include "pod2nerdm"; [.[]|extension]
+["a", "a.JPG", "a.b", "a.b.c", "trial3/trial3a.json.sha256", "trial3/trial3a.json", ".cshrc"]
+["", "JPG", "b", "c", "sha256", "json", ""]
 
 
 #---------------
@@ -132,6 +171,13 @@ include "pod2nerdm"; map(componentID("#"))
 include "pod2nerdm"; dist2download
 {"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json", "mediaType": "application/json","title": "Titanium Boride" }
 {"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"]}
+
+#--------------
+# testing dist2checksum()
+#
+include "pod2nerdm"; dist2checksum
+{"downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json.sha256", "title": "Checksum for srd13_B-101.json" }
+{"downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json.sha256","mediaType": "text/plain", "description": "SHA-256 checksum value for srd13_B-101.json", "title": "Checksum for srd13_B-101.json", "filepath":"srd13_B-101.json.sha256", "algorithm": {"@type": "Thing","tag": "sha256"},"@type": ["nrdp:ChecksumFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json.sha256","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/ChecksumFile"]}
 
 #--------------
 # testing dist2hidden()

--- a/jq/tests/test_pod2nerdm.jqt
+++ b/jq/tests/test_pod2nerdm.jqt
@@ -131,7 +131,7 @@ include "pod2nerdm"; map(componentID("#"))
 #
 include "pod2nerdm"; dist2download
 {"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json", "mediaType": "application/json","title": "Titanium Boride" }
-{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"]}
+{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"]}
 
 #--------------
 # testing dist2hidden()
@@ -171,7 +171,7 @@ include "pod2nerdm"; dist2comp
 #
 include "pod2nerdm"; dist2comp
 {"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json", "mediaType": "application/json","title": "Titanium Boride" }
-{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"]}
+{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"]}
 
 #--------------
 # testing dist2comp()
@@ -181,7 +181,7 @@ include "pod2nerdm"; dist2comp
 #
 include "pod2nerdm"; dist2comp
 {"accessURL": "http://www.nsrl.nist.gov/Downloads.htm","conformsTo": "http://www.nsrl.nist.gov/Documents/Data-Formats-of-the-NSRL-Reference-Data-Set-16.pdf","downloadURL": "http://www.nsrl.nist.gov/RDS/rds_2.50/RDS_250.iso","format": "ISO 9660 disk image","mediaType": "application/zip" }
-{"accessURL": "http://www.nsrl.nist.gov/Downloads.htm","conformsTo": "http://www.nsrl.nist.gov/Documents/Data-Formats-of-the-NSRL-Reference-Data-Set-16.pdf","downloadURL": "http://www.nsrl.nist.gov/RDS/rds_2.50/RDS_250.iso","format": { "description": "ISO 9660 disk image"},"mediaType": "application/zip", "filepath":"RDS_250.iso", "@type": ["nrdp:DataFile","dcat:Distribution"],"@id":"cmps/RDS_250.iso","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"] }
+{"accessURL": "http://www.nsrl.nist.gov/Downloads.htm","conformsTo": "http://www.nsrl.nist.gov/Documents/Data-Formats-of-the-NSRL-Reference-Data-Set-16.pdf","downloadURL": "http://www.nsrl.nist.gov/RDS/rds_2.50/RDS_250.iso","format": { "description": "ISO 9660 disk image"},"mediaType": "application/zip", "filepath":"RDS_250.iso", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/RDS_250.iso","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"] }
 
 #--------------
 # testing dist2comp()
@@ -252,16 +252,16 @@ include "pod2nerdm"; obj_types
 # file below a particular subcollection
 #
 include "pod2nerdm"; select_comp_within("foo/bar")
-[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{"title": "foo bar","filepath": "foo/bar","@type": ["nrdp:Subcollection"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
-[{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
+[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{"title": "foo bar","filepath": "foo/bar","@type": ["nrdp:Subcollection"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
+[{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
 
 # testing select_obj_type
 #
 # This successfully tests selecting a component from throughout the hierarchy
 #
 include "pod2nerdm"; select_obj_type("dcat:Distribution")
-[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{"title": "foo bar","filepath": "foo/bar","@type": ["nrdp:Subcollection"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
-[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]}]
+[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{"title": "foo bar","filepath": "foo/bar","@type": ["nrdp:Subcollection"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
+[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]}]
 
 # testing select_obj_type
 #
@@ -269,7 +269,7 @@ include "pod2nerdm"; select_obj_type("dcat:Distribution")
 # hierarchy.
 #
 include "pod2nerdm"; select_obj_type("nrdp:Subcollection")
-[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{"title": "foo bar","filepath": "foo/bar","@type": ["nrdp:Subcollection"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
+[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{"title": "foo bar","filepath": "foo/bar","@type": ["nrdp:Subcollection"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
 [{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "foo bar","filepath": "foo/bar","@type": ["nrdp:Subcollection"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
 
 # testing select_obj_type
@@ -278,7 +278,7 @@ include "pod2nerdm"; select_obj_type("nrdp:Subcollection")
 # type.
 #
 include "pod2nerdm"; select_obj_type("gurn:Goober")
-[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{"title": "foo bar","filepath": "foo/bar","@type": ["nrdp:Subcollection"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
+[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{"title": "foo bar","filepath": "foo/bar","@type": ["nrdp:Subcollection"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
 []
 
 # testing select_comp_type
@@ -286,7 +286,7 @@ include "pod2nerdm"; select_obj_type("gurn:Goober")
 # This tests selecting a type below a specific subcollection in the hierarchy.
 #
 include "pod2nerdm"; select_comp_type("nrdp:Subcollection"; "foo/bar")
-[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{"title": "foo bar","filepath": "foo/bar","@type": ["nrdp:Subcollection"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
+[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{"title": "foo bar","filepath": "foo/bar","@type": ["nrdp:Subcollection"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
 [{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
 
 # testing create_subcoll_for
@@ -298,8 +298,8 @@ include "pod2nerdm"; create_subcoll_for
 # testing insert_subcoll_comps
 #
 include "pod2nerdm"; insert_subcoll_comps
-[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
-[{"@id": "cmps/foo/bar", "@type": ["nrdp:Subcollection"], "filepath": "foo/bar", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection" ]},{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","dcat:Distribution"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
+[{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
+[{"@id": "cmps/foo/bar", "@type": ["nrdp:Subcollection"], "filepath": "foo/bar", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/Subcollection" ]},{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
 
 
 

--- a/jq/tests/test_podds2resource.py
+++ b/jq/tests/test_podds2resource.py
@@ -81,9 +81,10 @@ class TestJanaf(unittest.TestCase):  #
         self.assertIn(nerdmpub+"/definitions/DataFile", exts)
 
         typs = comps[0]['@type']
-        self.assertEquals(len(typs), 2)
+        self.assertEquals(len(typs), 3)
         self.assertEquals(typs[0], "nrdp:DataFile")
-        self.assertEquals(typs[1], "dcat:Distribution")
+        self.assertEquals(typs[1], "nrdp:DownloadableFile")
+        self.assertEquals(typs[2], "dcat:Distribution")
 
         props = "describedBy downloadURL".split()
         for prop in props:
@@ -181,9 +182,10 @@ class TestCORR(unittest.TestCase):  #
         self.assertIn(nerdmpub+"/definitions/DataFile", exts)
 
         typs = comps[3]['@type']
-        self.assertEquals(len(typs), 2)
+        self.assertEquals(len(typs), 3)
         self.assertEquals(typs[0], "nrdp:DataFile")
-        self.assertEquals(typs[1], "dcat:Distribution")
+        self.assertEquals(typs[1], "nrdp:DownloadableFile")
+        self.assertEquals(typs[2], "dcat:Distribution")
 
         props = "downloadURL".split()
         for prop in props:

--- a/model/nerdm-context.jsonld
+++ b/model/nerdm-context.jsonld
@@ -6,6 +6,7 @@
         "foaf": "http://xmlns.com/foaf/0.1/",
         "vivo": "http://vivoweb.org/ontology/core#",
         "ore": "http://www.openarchives.org/ore/terms/",
+        "ov": "http://vocab.org/open/",
         "dpr": "https://nist.org/dp/dpr/",
         "vcard": "http://www.w3.org/2006/vcard/ns#",
         "bibo": "http://purl.org/ontology/bibo/",

--- a/model/nerdm-pub-schema.json
+++ b/model/nerdm-pub-schema.json
@@ -329,6 +329,25 @@
                 { "$ref": "#/definitions/DownloadableFile" },
                 {
                     "properties": {
+                        "algorithm": {
+                            "description": "the algorithm used to produce the checksum hash",
+                            "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Topic"
+                        },
+                        
+                        "valid": {
+                            "type": "boolean",
+                            "description": "A flag, if True, indicating the the hash value contained in this ChecksumFile is confirmed to be correct for its associated data file."
+                        },
+                        
+                        "describes": {
+                            "type": "string",
+                            "format": "uri-reference"
+                            "asOntology": {
+                                "@context": "profile-schema-onto.json",
+                                "prefLabel": "Checksum for",
+                                "referenceProperty": "ov:describes"
+                            }
+                        }
                     }
                 }
             ]

--- a/model/nerdm-pub-schema.json
+++ b/model/nerdm-pub-schema.json
@@ -341,7 +341,7 @@
                         
                         "describes": {
                             "type": "string",
-                            "format": "uri-reference"
+                            "format": "uri-reference",
                             "asOntology": {
                                 "@context": "profile-schema-onto.json",
                                 "prefLabel": "Checksum for",

--- a/model/nerdm-pub-schema.json
+++ b/model/nerdm-pub-schema.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$extensionSchemas": ["https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
+    "$extensionSchemas": ["https://data.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
     "id": "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#",
-    "rev": "wd1",
+    "rev": "wd2",
     "title": "The NERDm extension metadata for Public Data",
     "description": "These classes extend the based NERDm schema to different types of published data",
     "definitions": {
@@ -181,7 +181,7 @@
             "required": [ "filepath" ]
         },
 
-        "DataFile": {
+        "DownloadableFile": {
             "description": "a description of a downloadable, finite stream of data",
             "allOf": [
                 { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/Component" },
@@ -241,6 +241,46 @@
                             }
                         },
                 
+                        "checksum": {
+                            "title": "Checksum",
+                            "description": "a checksum for the file",
+                            "$ref": "#/definitions/Checksum"
+                        },
+
+                        "size": {
+                            "description": "the size of the file in bytes",
+                            "type": "integer",
+                            "asOntology": {
+                                "@context": "profile-schema-onto.json",
+                                "prefLabel": "file size",
+                                "referenceProperty": "schema:fileSize"
+                            }
+                        }
+                        
+                    },
+                    "required": [ "filepath" ],
+
+                    "dependencies": {
+                        "downloadURL": {
+                            "properties": {
+                                "mediaType": {
+                                    "type": "string",
+                                    "pattern": "^[-\\w]+/[-\\w]+(\\.[-\\w]+)*([+][-\\w]+)?$"
+                                }
+                            },
+                            "required": [ "mediaType" ]
+                        }
+                    }
+                }
+            ]
+        },
+
+        "DataFile": {
+            "description": "a description of a downloadable file that was provided by the authors (as opposed to a system or checksum file produced by the publication system).",
+            "allOf": [
+                { "$ref": "#/definitions/DownloadableFile" },
+                {
+                    "properties": {
                         "describedBy": {
                             "title": "Data Dictionary",
                             "description": "URL to the data dictionary for the distribution found at the downloadURL",
@@ -277,37 +317,18 @@
                                 "prefLabel": "Data Dictionary Type",
                                 "referenceProperty": "pod:describedByType"
                             }
-                        },
-
-                        "checksum": {
-                            "title": "Checksum",
-                            "description": "a checksum for the file",
-                            "$ref": "#/definitions/Checksum"
-                        },
-
-                        "size": {
-                            "description": "the size of the file in bytes",
-                            "type": "integer",
-                            "asOntology": {
-                                "@context": "profile-schema-onto.json",
-                                "prefLabel": "file size",
-                                "referenceProperty": "schema:fileSize"
-                            }
                         }
-                        
-                    },
-                    "required": [ "filepath" ],
+                    }
+                }
+            ]
+        },
 
-                    "dependencies": {
-                        "downloadURL": {
-                            "properties": {
-                                "mediaType": {
-                                    "type": "string",
-                                    "pattern": "^[-\\w]+/[-\\w]+(\\.[-\\w]+)*([+][-\\w]+)?$"
-                                }
-                            },
-                            "required": [ "mediaType" ]
-                        }
+        "ChecksumFile": {
+            "description": "a downloadable file that contains the checksum value for a DataFile.",
+            "allOf": [
+                { "$ref": "#/definitions/DownloadableFile" },
+                {
+                    "properties": {
                     }
                 }
             ]

--- a/model/profile-schema-onto.json
+++ b/model/profile-schema-onto.json
@@ -3,6 +3,7 @@
         "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
         "owl": "http://www.w3.org/2002/07/owl#",
+        "ov": "http://vocab.org/open/",
         "skos": "http://www.w3.org/2004/02/skos/core#",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "psch": "http://www.nist.gov/dp/di/ont/pod-onto.json#",


### PR DESCRIPTION
This is a follow-on to [ODD-611](http://mml.nist.gov:8080/browse/ODD-611).   The sha256 checksum files generated by MIDAS were not consistently appearing as files on the landing page; those that did were not always downloadable.  This PR helps provide consistent support for checksum files.  In particular, in this repo, the PR updates the NERDm schema by defining a new component type "ChecksumFile".  The pod2nerdm jq library has been updated accordingly to recognize .sha256 files.  

This PR has a companion [PR 31 to the oar-pdr repo](https://github.com/usnistgov/oar-pdr/pull/31), which updates metadata generation and bag-building accordingly.  

