### PR TITLE
ODD-612: decode downloadURLs when setting filepath

### DIFF
--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -17,6 +17,7 @@
 # Here, CATFILE is the POD catalog file.  (In this example, the output records
 # are all given a null identifier.)
 
+include "urldecode";
 
 # the base NERDm JSON schema namespace
 #
@@ -202,7 +203,7 @@ def filepath:
           end
         end
       end
-    end
+    end | url_decode
 ;
 
 # conversion for a POD-to-NERDm distribution node.  A distribution with a

--- a/jq/tests/test_pod2nerdm.jqt
+++ b/jq/tests/test_pod2nerdm.jqt
@@ -52,6 +52,14 @@ include "pod2nerdm"; map(cvtref)
 [{ "@type": "deo:BibliographicReference","@id":"#ref:doc1.txt", "refType": "IsReferencedBy", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference" ], "location": "http://goob.net/doc1.txt"}, { "@type": "deo:BibliographicReference","@id":"#ref:doc2.txt", "refType": "IsReferencedBy", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference" ], "location": "https://goob.gov/doc2.txt"}]
 
 #---------------
+# testing filepath()
+#
+include "pod2nerdm"; map(filepath)
+[ "http://goob.net/root/doc.txt", "https://s3.amazonaws.com/nist-zub/90210/foo/bar", "http://s3.amazonaws.com/nist-srd/14/data.zip", "https://data.nist.gov/od/ds/2309849843752/my%20data.zip", "https://testdata.nist.gov/od/ds/2309849843752/coll%23/my%20data.zip" ]
+[ "doc.txt", "foo/bar", "data.zip", "my data.zip", "coll#/my data.zip" ]
+
+
+#---------------
 # testing urlpath()
 #
 include "pod2nerdm"; map(urlpath)
@@ -137,7 +145,7 @@ include "pod2nerdm"; basename
 #---------------
 # testing remove_extension
 #
-include "pod2nerdm"; [.[]|remove_extension]
+include "pod2nerdm"; map(remove_extension)
 ["a", "a.JPG", "a.b", "a.b.c", "trial3/trial3a.json.sha256", "trial3/trial3a.json", ".cshrc"]
 ["a", "a", "a", "a.b", "trial3/trial3a.json", "trial3/trial3a", ".cshrc"]
 
@@ -145,7 +153,7 @@ include "pod2nerdm"; [.[]|remove_extension]
 #---------------
 # testing extension
 #
-include "pod2nerdm"; [.[]|extension]
+include "pod2nerdm"; map(extension)
 ["a", "a.JPG", "a.b", "a.b.c", "trial3/trial3a.json.sha256", "trial3/trial3a.json", ".cshrc"]
 ["", "JPG", "b", "c", "sha256", "json", ""]
 

--- a/jq/urldecode.jq
+++ b/jq/urldecode.jq
@@ -1,0 +1,45 @@
+# URL decoding library
+#
+# This implementation comes from https://rosettacode.org/wiki/URL_decoding#jq
+# (modified 8 April 2018) and is made available under GNU Free Documentation
+# License 1.2.
+
+# Emit . and stop as soon as "condition" is true.
+#
+# Input:     any 
+# Output:    same as input
+# condition: conditional code 
+# next:      filter to apply if condition is false
+# 
+def until(condition; next):
+  def u: if condition then . else (next|u) end;
+  u;
+
+# replace all url-encodings (%XX) in an input string with their unencoded
+# characters.
+#
+# Input:  string
+# Output: string
+# 
+def url_decode:
+  # The helper function converts the input string written in the given
+  # "base" to an integer
+  def to_i(base):
+    explode
+    | reverse
+    | map(if 65 <= . and . <= 90 then . + 32  else . end)   # downcase
+    | map(if . > 96  then . - 87 else . - 48 end)  # "a" ~ 97 => 10 ~ 87
+    | reduce .[] as $c
+        # base: [power, ans]
+        ([1,0]; (.[0] * base) as $b | [$b, .[1] + (.[0] * $c)]) | .[1];
+ 
+  .  as $in
+  | length as $length
+  | [0, ""]  # i, answer
+  | until ( .[0] >= $length;
+      .[0] as $i
+      |  if $in[$i:$i+1] == "%"
+         then [ $i + 3, .[1] + ([$in[$i+1:$i+3] | to_i(16)] | implode) ]
+         else [ $i + 1, .[1] + $in[$i:$i+1] ]
+         end)
+  | .[1];  # answer


### PR DESCRIPTION
This addresses [ODD-612 ("PDR-publish: files with URL-encodable parameters get listed twice")](http://mml.nist.gov:8080/browse/ODD-612) which describes how special characters in filenames were confusing the metadata service and causing them to be added twice, one with the characters URL-encoded and one unencoded.  The key to fixing this is ensuring that when converting between `downloadURL` and `filepath` properties, it is necessary to url-encode and decode.  

This PR has a companion [PR 32 to oar-pdr](https://github.com/usnistgov/oar-pdr/pull/32).  In this PR, url-decoding has been added to the `jq` `pod2nerdm` filter library when converting a `downloadURL` to a `filepath`.  (Encoding happens in the [oar-pdr PR 32](https://github.com/usnistgov/oar-pdr/pull/32).)