### PR TITLE
fix python docker-build failure by upgrading setuptools

### DIFF
--- a/docker/ejsonschema/Dockerfile
+++ b/docker/ejsonschema/Dockerfile
@@ -2,6 +2,7 @@ FROM oar-metadata/jq:latest
 
 RUN apt-get update && apt-get install -y python python-pip python-dev unzip \
                                          uwsgi uwsgi-plugin-python python-yaml
+RUN pip install setuptools --upgrade
 RUN pip install json-spec jsonmerge==1.3.0 jsonschema requests pynoid pytest filelock 
 
 WORKDIR /root


### PR DESCRIPTION
An apparent change in a dependent python module (pytest) is causing docker-build failures (e.g. as seen with the [Travis build 733](https://travis-ci.org/usnistgov/oar-pdr/builds/553470104?utm_source=github_status) for [oar-pdr PR#81](https://github.com/usnistgov/oar-pdr/pull/81)).  This failure is fixed by upgrading the python module, `setuptools`, in `docker/ejsonschema/Dockerfile`.
