### PR TITLE
Fix failing json validation unit test failures

### DIFF
--- a/docker/ejsonschema/Dockerfile
+++ b/docker/ejsonschema/Dockerfile
@@ -3,7 +3,7 @@ FROM oar-metadata/jq:latest
 RUN apt-get update && apt-get install -y python python-pip python-dev unzip \
                                          uwsgi uwsgi-plugin-python python-yaml
 RUN pip install setuptools --upgrade
-RUN pip install json-spec jsonmerge==1.3.0 jsonschema requests pynoid \
+RUN pip install json-spec jsonmerge==1.3.0 jsonschema==2.6.0 requests pynoid \
                 pytest==4.6.5 filelock crossrefapi
 
 WORKDIR /root

--- a/model/nerdm-context.jsonld
+++ b/model/nerdm-context.jsonld
@@ -10,6 +10,8 @@
         "dpr": "https://nist.org/dp/dpr/",
         "vcard": "http://www.w3.org/2006/vcard/ns#",
         "bibo": "http://purl.org/ontology/bibo/",
+        "schema": "http://schema.org/",
+        "npg":  "http://ns.nature.com/terms/",
         "skos": "http://www.w3.org/2004/02/skos/core#",
         "pod": "https://project-open-data.cio.gov/v1.1/schema#",
         "rmmperson": "https://nist.org/od/dm/person/",

--- a/model/pod-schema.json
+++ b/model/pod-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "$extensionSchemas": ["http://mgi.nist.gov/mgi-json-schema/v0.1"],
-    "id": "http://data.nist.gov/od/dm/pod-schema/v1.1#",
+    "id": "https://data.nist.gov/od/dm/pod-schema/v1.1#",
     "title": "US Project Open Data Schema as Extended JSON Schema",
     "description": "This JSON Schema expresses the POD schema (v1.1) so that instances can be validated via a JSON Schema validater",
     "definitions": {


### PR DESCRIPTION
This PR fixes some unit test failures that began occurring due to some "out-of-band" changes.  This included the appearance of a new jsonschema python library that is not compatible with our current schema documents.  Also a mismatch in the POD schema URI was causing some new [oar-pdr](https://github.com/usnistgov/oar-pdr) unit tests to fail.  Both of these are addressed:  The POD schema URI was updated and a max-version restriction of 2.6.0 was put on jsonschema.  (This also needs to be put into `oar-docker`.).
