### PR TITLE
Fix POD-to-NERDm conversion: allow for ark IDs in download URLs

### DIFF
--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -191,14 +191,14 @@ def filepath:
         if test("https?://opendata.nist.gov/\\w+/") then
            sub("https?://opendata.nist.gov/\\w+/"; "")
         else
-          if test("https?://data.nist.gov/od/ds/\\w+/") then
-             sub("https?://data.nist.gov/od/ds/\\w+/"; "")
+          if test("https?://(test)?data.nist.gov/od/ds/") then
+             sub("https?://(test)?data.nist.gov/od/ds/"; "") |
+             if test("ark:/\\w+/") then
+                sub("ark:/\\w+/"; "")
+             else . end |
+             sub("^[\\w+-]+/"; "") 
           else
-            if test("https?://testdata.nist.gov/od/ds/\\w+/") then
-               sub("https?://testdata.nist.gov/od/ds/\\w+/"; "")
-            else
-               sub(".*/"; "")
-            end
+            sub(".*/"; "")
           end
         end
       end

--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -184,24 +184,18 @@ def componentID(prefix):
 def filepath:
     if test("https?://s3.amazonaws.com/nist-srd/\\w+/") then
        sub("https?://s3.amazonaws.com/nist-srd/\\w+/"; "")
+    elif test("https?://s3.amazonaws.com/nist-\\w+/\\w+/") then
+       sub("https?://s3.amazonaws.com/nist-\\w+/\\w+/"; "")
+    elif test("https?://opendata.nist.gov/\\w+/") then
+       sub("https?://opendata.nist.gov/\\w+/"; "")
+    elif test("https?://(test)?data.nist.gov/od/ds/") then
+       sub("https?://(test)?data.nist.gov/od/ds/"; "") |
+       if test("ark:/\\w+/") then
+          sub("ark:/\\w+/"; "")
+       else . end |
+       sub("^[\\w+-]+/"; "") 
     else
-      if test("https?://s3.amazonaws.com/nist-\\w+/\\w+/") then
-         sub("https?://s3.amazonaws.com/nist-\\w+/\\w+/"; "")
-      else
-        if test("https?://opendata.nist.gov/\\w+/") then
-           sub("https?://opendata.nist.gov/\\w+/"; "")
-        else
-          if test("https?://(test)?data.nist.gov/od/ds/") then
-             sub("https?://(test)?data.nist.gov/od/ds/"; "") |
-             if test("ark:/\\w+/") then
-                sub("ark:/\\w+/"; "")
-             else . end |
-             sub("^[\\w+-]+/"; "") 
-          else
-            sub(".*/"; "")
-          end
-        end
-      end
+       sub(".*/"; "")
     end | url_decode_plus
 ;
 

--- a/jq/tests/test_pod2nerdm.jqt
+++ b/jq/tests/test_pod2nerdm.jqt
@@ -55,8 +55,8 @@ include "pod2nerdm"; map(cvtref)
 # testing filepath()
 #
 include "pod2nerdm"; map(filepath)
-[ "http://goob.net/root/doc.txt", "https://s3.amazonaws.com/nist-zub/90210/foo/bar", "http://s3.amazonaws.com/nist-srd/14/data.zip", "https://data.nist.gov/od/ds/2309849843752/my%20data.zip", "https://testdata.nist.gov/od/ds/2309849843752/coll%23/my+%2Bdata.zip" ]
-[ "doc.txt", "foo/bar", "data.zip", "my data.zip", "coll#/my +data.zip" ]
+[ "http://goob.net/root/doc.txt", "https://s3.amazonaws.com/nist-zub/90210/foo/bar", "http://s3.amazonaws.com/nist-srd/14/data.zip", "https://data.nist.gov/od/ds/2309849843752/my%20data.zip", "https://testdata.nist.gov/od/ds/2309849843752/coll%23/my+%2Bdata.zip", "https://testdata.nist.gov/od/ds/ark:/88888/pdr0-19381/coll%23/my+%2Bdata.zip", "https://data.nist.gov/od/ds/ark:/88888/pdr0-19381/my+%2Bdata.zip" ]
+[ "doc.txt", "foo/bar", "data.zip", "my data.zip", "coll#/my +data.zip", "coll#/my +data.zip", "my +data.zip" ]
 
 
 #---------------


### PR DESCRIPTION
In the recently update to add support ARK-based EDI IDs, I neglected to update the algorithm in the JQ transfrom library, `pod2nerdm`, used for converting a `downloadURL` to a `filepath`.  Thus, the converter was not able to detect file hierarchies.  This PR fixes this problem.  