### PR TITLE
pod2nerdm: don't make conversion dependent on data.nist.gov urls

### DIFF
--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -188,8 +188,8 @@ def filepath:
        sub("https?://s3.amazonaws.com/nist-\\w+/\\w+/"; "")
     elif test("https?://opendata.nist.gov/\\w+/") then
        sub("https?://opendata.nist.gov/\\w+/"; "")
-    elif test("https?://(test)?data.nist.gov/od/ds/") then
-       sub("https?://(test)?data.nist.gov/od/ds/"; "") |
+    elif test("https?://[\\w\\.:]+/od/ds/") then
+       sub("https?://[\\w\\.:]+/od/ds/"; "") |
        if test("ark:/\\w+/") then
           sub("ark:/\\w+/"; "")
        else . end |


### PR DESCRIPTION
The module that converts NERDm records to POD detect hierarchical collections by looking at the downloadURLs, and it would only do this detection for URLs that appear to be provided by the distribution service.  Previously, such URLs were recognized if they started with a URL base pattern that explicitly included the data.nist.gov server (or testdata.nist.gov).  In this PR, this is changed to allow any server name as long as the base path is `/od/ds/`. 

One of the motivators for this change is to allow unit tests in `oar-pdr` to use a local simulated distribution service rather than relying on the production service at data.nist.gov.  If the production is service is down or otherwise unavailable (e.g. on an airplane), these tests would fail (or, actually, hang).