### PR TITLE
ODD-859: Fix propagation of research themes into NERDm records

### DIFF
--- a/model/theme-taxonomy-pre1.0.json
+++ b/model/theme-taxonomy-pre1.0.json
@@ -2,7 +2,7 @@
     "_schema": "https://www.nist.gov/od/dm/simple-taxonomy/v1.0",
     "@id": "https://www.nist.gov/od/dm/nist-themes/v1.0",
     "title": "The NIST Research Theme Taxonomy",
-    "version": "1.1",
+    "version": "1.0",
     "description": "terms for tagging resources with research themes",
     "vocab": [
         {
@@ -35,12 +35,6 @@
         },
         {
             "parent": "Bioscience",
-            "term": "Biomolecular Characterization",
-            "level": 2,
-            "since": "1.1"
-        },
-        {
-            "parent": "Bioscience",
             "term": "Bioprocessing",
             "level": 2
         },
@@ -56,26 +50,17 @@
         },
         {
             "parent": "Bioscience",
-            "term": "Genomics",
-            "level": 2,
-            "since": "1.1"
-        },
-        {
-            "parent": "Bioscience",
             "term": "Genomic measurements",
-            "level": 2,
-            "deprecatedSince": "1.1",
-            "deprecatedBy": "Bioscience: Genomics"
-        },
-        {
-            "parent": "Bioscience",
-            "term": "Lipidomics",
-            "level": 2,
-            "deprecatedSince": "1.1"
+            "level": 2
         },
         {
             "parent": "Bioscience",
             "term": "Glycomics",
+            "level": 2
+        },
+        {
+            "parent": "Bioscience",
+            "term": "Lipidomics",
             "level": 2
         },
         {
@@ -94,16 +79,8 @@
         },
         {
             "parent": "Buildings and Construction",
-            "term": "Heating, ventilation, and air conditioning equipment",
-            "level": 2,
-            "since": "1.1"
-        },
-        {
-            "parent": "Buildings and Construction",
-            "term": "Air conditioning equipment and heating",
-            "level": 2,
-            "deprecatedSince": "1.1",
-            "deprecatedBy": "Buildings and Construction: Heating, ventilation, and air conditioning equipment"
+            "term": "Air conditioning and heating equipment",
+            "level": 2
         },
         {
             "parent": "Buildings and Construction",
@@ -137,18 +114,7 @@
         },
         {
             "parent": "Buildings and Construction",
-            "term": "Resilient buildings",
-            "level": 2,
-            "since": "1.1"
-        },
-        {
-            "parent": "Buildings and Construction",
             "term": "Structural engineering",
-            "level": 2
-        },
-        {
-            "parent": "Buildings and Construction",
-            "term": "Sustainable buildings",
             "level": 2
         },
         {
@@ -193,12 +159,6 @@
             "parent": "Electronics",
             "term": "Electromagnetics",
             "level": 2
-        },
-        {
-            "parent": "Electronics",
-            "term": "Flexible electronics",
-            "level": 2,
-            "since": "1.1"
         },
         {
             "parent": "Electronics",
@@ -353,16 +313,8 @@
         },
         {
             "parent": "Forensics",
-            "term": "Digital evidence",
-            "level": 2,
-            "since": "1.1"
-        },
-        {
-            "parent": "Forensics",
             "term": "Digital and multimedia evidence",
-            "level": 2,
-            "deprecatedSince": "1.1",
-            "deprecatedBy": "Forensics: Digital evidence"
+            "level": 2
         },
         {
             "parent": "Forensics",
@@ -376,16 +328,8 @@
         },
         {
             "parent": "Forensics",
-            "term": "Fingerprints and pattern evidence",
-            "level": 2,
-            "since": "1.1"
-        },
-        {
-            "parent": "Forensics",
             "term": "Pattern evidence",
-            "level": 2,
-            "deprecatedSince": "1.1",
-            "deprecatedBy": "Forensics: Fingerprints and pattern evidence"
+            "level": 2
         },
         {
             "parent": "Forensics",
@@ -399,8 +343,7 @@
         {
             "parent": "Health",
             "term": "Cell therapies",
-            "level": 2,
-            "deprecatedSince": "1.1"
+            "level": 2
         },
         {
             "parent": "Health",
@@ -435,23 +378,11 @@
         {
             "parent": "Health",
             "term": "Radiation therapies",
-            "level": 2,
-            "deprecatedSince": "1.1"
-        },
-        {
-            "parent": "Health",
-            "term": "Regenerative medicine",
-            "level": 2,
-            "since": "1.1"
+            "level": 2
         },
         {
             "term": "Information Technology",
             "level": 1
-        },
-        {
-            "parent": "Information Technology",
-            "term": "Artificial Intelligence",
-            "level": 2
         },
         {
             "parent": "Information Technology",
@@ -496,9 +427,7 @@
         {
             "parent": "Information Technology: Cybersecurity",
             "term": "Access control",
-            "level": 3,
-            "deprecatedSince": "1.1",
-            "deprecatedBy": "Information Technology: Cybersecurity: Identity and access management"
+            "level": 3
         },
         {
             "parent": "Information Technology: Cybersecurity",
@@ -538,9 +467,7 @@
         {
             "parent": "Information Technology: Data and informatics",
             "term": "Video analytics",
-            "level": 3,
-            "deprecatedSince": "1.1",
-            "deprecatedBy": "Information Technology: Video analytics"
+            "level": 3
         },
         {
             "parent": "Information Technology",
@@ -550,40 +477,17 @@
         {
             "parent": "Information Technology",
             "term": "Healthcare IT",
-            "level": 2,
-            "deprecatedSince": "1.1"
-        },
-        {
-            "parent": "Information Technology",
-            "term": "Health IT",
-            "level": 2,
-            "since": "1.1"
-        },
-        {
-            "parent": "Information Technology",
-            "term": "Identity and access management",
-            "level": 2,
-            "since": "1.1"
+            "level": 2
         },
         {
             "parent": "Information Technology",
             "term": "Identity management",
-            "level": 2,
-            "deprecatedSince": "1.1",
-            "deprecatedBy": "Information Technology: Identity and access management"
-        },
-        {
-            "parent": "Information Technology",
-            "term": "Internet of Things (IoT)",
-            "level": 2,
-            "since": "1.1"
+            "level": 2
         },
         {
             "parent": "Information Technology",
             "term": "Internet of Things",
-            "level": 2,
-            "deprecatedSince": "1.1",
-            "deprecatedBy": "Information Technology: Internet of Things"
+            "level": 2
         },
         {
             "parent": "Information Technology",
@@ -602,64 +506,13 @@
         },
         {
             "parent": "Information Technology: Networking",
-            "term": "Mobile and Wireless Networking",
-            "level": 3,
-            "since": "1.0"
-        },
-        {
-            "parent": "Information Technology: Networking",
-            "term": "Network Management and Monitoring",
+            "term": "Network modeling",
             "level": 3
         },
         {
             "parent": "Information Technology: Networking",
-            "term": "Network Modeling and Analysis",
-            "level": 3,
-            "since": "1.0"
-        },
-        {
-            "parent": "Information Technology: Networking",
-            "term": "Network modeling",
-            "level": 3,
-            "deprecatedSince": "1.0",
-            "deprecatedBy": "Information Technology: Networking: Network Modeling and Analysis"
-        },
-        {
-            "parent": "Information Technology: Networking",
-            "term": "Network Security and Robustness",
-            "level": 3,
-            "since": "1.0"
-        },
-        {
-            "parent": "Information Technology: Networking",
-            "term": "Network Test and Measurement",
-            "level": 3,
-            "since": "1.0"
-        },
-        {
-            "parent": "Information Technology: Networking",
-            "term": "Next Generation Networks",
-            "level": 3,
-            "deprecatedSince": "1.0"
-        },
-        {
-            "parent": "Information Technology: Networking",
             "term": "Next generation internet",
-            "level": 3,
-            "deprecatedSince": "1.0",
-            "deprecatedBy": "Information Technology: Networking: Next Generation Networks"
-        },
-        {
-            "parent": "Information Technology: Networking",
-            "term": "Protocol Design and Standardization",
-            "level": 3,
-            "deprecatedSince": "1.0"
-        },
-        {
-            "parent": "Information Technology: Networking",
-            "term": "Software Defined and Virtual networks",
-            "level": 3,
-            "deprecatedSince": "1.0"
+            "level": 3
         },
         {
             "parent": "Information Technology",
@@ -698,11 +551,6 @@
         },
         {
             "parent": "Information Technology",
-            "term": "Video analytics",
-            "level": 2
-        },
-        {
-            "parent": "Information Technology",
             "term": "Visualization research",
             "level": 2
         },
@@ -732,8 +580,7 @@
         {
             "parent": "Manufacturing",
             "term": "Exports",
-            "level": 2,
-            "deprecatedSince": "1.1"
+            "level": 2
         },
         {
             "parent": "Manufacturing",
@@ -753,8 +600,7 @@
         {
             "parent": "Manufacturing",
             "term": "Lean manufacturing",
-            "level": 2,
-            "deprecatedSince": "1.1"
+            "level": 2
         },
         {
             "parent": "Manufacturing",
@@ -764,11 +610,6 @@
         {
             "parent": "Manufacturing",
             "term": "Manufacturing systems design and analysis",
-            "level": 2
-        },
-        {
-            "parent": "Manufacturing",
-            "term": "Monitoring, diagnostics and prognostics",
             "level": 2
         },
         {
@@ -798,38 +639,37 @@
         },
         {
             "parent": "Manufacturing: Robotics in manufacturing",
+            "term": "Collaborative Robots",
+            "level": 3
+        },
+        {
+            "parent": "Manufacturing: Robotics in manufacturing",
+            "term": "Desterous Grasping",
+            "level": 3
+        },
+        {
+            "parent": "Manufacturing: Robotics in manufacturing",
+            "term": "Industrial Autonomous Vehicles",
+            "level": 3
+        },
+        {
+            "parent": "Manufacturing: Robotics in manufacturing",
+            "term": "Mobile Manipulators",
+            "level": 3
+        },
+        {
+            "parent": "Manufacturing: Robotics in manufacturing",
             "term": "Agility and adaptability",
             "level": 3
         },
         {
             "parent": "Manufacturing: Robotics in manufacturing",
-            "term": "Collaborative robots",
-            "level": 3
-        },
-        {
-            "parent": "Manufacturing: Robotics in manufacturing",
-            "term": "Dexterous grasping",
-            "level": 3,
-            "since": "1.1"
-        },
-        {
-            "parent": "Manufacturing: Robotics in manufacturing",
-            "term": "Industrial autonomous vehicles",
-            "level": 3
-        },
-        {
-            "parent": "Manufacturing: Robotics in manufacturing",
-            "term": "Mobile manipulators",
+            "term": "Sensing and perception",
             "level": 3
         },
         {
             "parent": "Manufacturing: Robotics in manufacturing",
             "term": "Navigation / actuation / control",
-            "level": 3
-        },
-        {
-            "parent": "Manufacturing: Robotics in manufacturing",
-            "term": "Sensing and perception",
             "level": 3
         },
         {
@@ -860,8 +700,7 @@
         {
             "parent": "Manufacturing",
             "term": "Work force",
-            "level": 2,
-            "deprecatedSince": "1.0"
+            "level": 2
         },
         {
             "term": "Materials",
@@ -993,8 +832,7 @@
         {
             "parent": "Metrology",
             "term": "Environmental metrology",
-            "level": 2,
-            "deprecatedSince": "1.1"
+            "level": 2
         },
         {
             "parent": "Metrology",
@@ -1288,15 +1126,12 @@
         {
             "parent": "Resilience",
             "term": "Disaster and failure studies",
-            "level": 2,
-            "since": "1.0"
+            "level": 2
         },
         {
             "parent": "Resilience",
             "term": "Disaster resilience",
-            "level": 2,
-            "deprecatedSince": "1.0",
-            "deprecatedBy": "Resilience: Disaster and failure studies"
+            "level": 2
         },
         {
             "parent": "Resilience",
@@ -1334,14 +1169,13 @@
         },
         {
             "parent": "Standards",
-            "term": "Conformity assessment",
+            "term": "Commercial standards",
             "level": 2
         },
         {
             "parent": "Standards",
-            "term": "Commercial standards",
-            "level": 2,
-            "deprecatedSince": "1.1"
+            "term": "Conformity assessment",
+            "level": 2
         },
         {
             "parent": "Standards",

--- a/model/theme-taxonomy.json
+++ b/model/theme-taxonomy.json
@@ -1,6 +1,6 @@
 {
-    "_schema": "https://www.nist.gov/od/dm/simple-taxonomy/v1.0",
-    "@id": "https://www.nist.gov/od/dm/nist-themes/v1.1",
+    "_schema": "https://data.nist.gov/od/dm/simple-taxonomy/v1.0",
+    "@id": "https://data.nist.gov/od/dm/nist-themes/v1.1",
     "title": "The NIST Research Theme Taxonomy",
     "version": "1.1",
     "description": "terms for tagging resources with research themes",

--- a/model/theme-taxonomy.json
+++ b/model/theme-taxonomy.json
@@ -1,6 +1,6 @@
 {
     "_schema": "https://www.nist.gov/od/dm/simple-taxonomy/v1.0",
-    "@id": "https://www.nist.gov/od/dm/nist-themes/v1.0",
+    "@id": "https://www.nist.gov/od/dm/nist-themes/v1.1",
     "title": "The NIST Research Theme Taxonomy",
     "version": "1.1",
     "description": "terms for tagging resources with research themes",
@@ -583,7 +583,7 @@
             "term": "Internet of Things",
             "level": 2,
             "deprecatedSince": "1.1",
-            "deprecatedBy": "Information Technology: Internet of Things"
+            "deprecatedBy": "Information Technology: Internet of Things (IoT)"
         },
         {
             "parent": "Information Technology",

--- a/python/nistoar/nerdm/constants.py
+++ b/python/nistoar/nerdm/constants.py
@@ -36,3 +36,22 @@ def schema_uri_for(schema_base, version):
 CORE_SCHEMA_URI = core_schema_uri_for(schema_versions[0])
 PUB_SCHEMA_URI = pub_schema_uri_for(schema_versions[0])
 
+TAXONOMY_VOCAB_BASE_URI = "https://data.nist.gov/od/dm/nist-themes/"
+TAXONOMY_VOCAB_INIT_URI = "https://www.nist.gov/od/dm/nist-themes/v1.0"
+
+taxon_versions = ["v1.1", "v1.0"]
+
+def taxon_uri_for(taxon_base, version):
+    """
+    return the schema URI for the requested version of the Core NERDm schema
+    @raises ValueError   if the given version is not a recognized version
+    """
+    if version in taxon_versions:
+        return taxon_base+version
+    vers = "v" + version
+    if vers in taxon_versions:
+        return taxon_base+vers
+
+    raise ValueError("Not an recognized NERDm version: " + version)
+
+TAXONOMY_VOCAB_URI = taxon_uri_for(TAXONOMY_VOCAB_BASE_URI, taxon_versions[0])

--- a/python/nistoar/nerdm/taxonomy.py
+++ b/python/nistoar/nerdm/taxonomy.py
@@ -1,0 +1,140 @@
+"""
+module for matching terms from the NIST research topic taxonomy
+"""
+import os, re, json
+from collections import OrderedDict
+
+class ResearchTopicsTaxonomy(object):
+    """
+    a container and interface to the NIST research topic taxonomy
+    """
+
+    def __init__(self, taxjson):
+        """
+        initialize the instance by wrapping the JSON-encoded taxonomy description
+        :param dict taxjson:  the taxonomy data 
+        """
+        self.data = taxjson
+        self.taillu = None
+        self.fulllu = None
+        self._mklus()
+
+    @classmethod
+    def from_file(cls, vocabfile):
+        """
+        given the taxonomy data description file, create an instance
+        """
+        if not os.path.exists(vocabfile):
+            raise RuntimeError("Unable to find taxonomy file: "+vocabfile)
+
+        with open(vocabfile) as fd:
+            data = json.load(fd, object_pairs_hook=OrderedDict)
+        return cls(data)
+
+    @classmethod
+    def from_schema_dir(cls, schemadir):
+        """
+        given directory containing the taxonomy data description file, 
+        create an instance of the taxonomy class
+        """
+        return cls.from_file(os.path.join(schemadir, "theme-taxonomy.json"))
+
+    def _mklus(self):
+        self.taillu = OrderedDict()
+        self.fulllu = OrderedDict()
+        for termdef in self.data['vocab']:
+            termdef['fullterm'] = self.TaxonomyTerm.make_full_term(termdef)
+            self.taillu[termdef['term']] = termdef
+            self.fulllu[termdef['fullterm']] = termdef
+
+    _match_ignore = "& / and or".split()
+    _ignore_chars = re.compile(r"[()/:]")
+    
+    def match_theme(self, theme, latest=True):
+        """
+        given a theme, find its best match to a vocabulary term.  This 
+        converts terms that may not be quite exact--e.g. mismatched 
+        capitalization, extra words, missing parent terms--to be converted
+        to exact taxonomy terms.  It can also convert deprecated terms to 
+        their latest counterparts.  
+        :param str theme:  the theme value of interest
+        :rtype TaxonomyTerm:  the vocabulary terms definition data
+        """
+        out = None
+
+        # try an exact match
+        if theme in self.fulllu:
+            out = self.fulllu[theme]
+        if theme in self.taillu:
+            out = self.taillu[theme]
+
+        if not out:
+            # try a near match
+            words = [w for w in self._ignore_chars.sub(' ', theme).split()
+                       if w not in self._match_ignore]
+
+            # find the theme words in the same order
+            patt = r"\b" + r"\b.*\b".join(words) + r"\b"
+            matchagainst = (':' in theme and 'fullterm') or 'term'
+            matches = [t for t in self.data['vocab']
+                         if re.search(patt,
+                                      self._ignore_chars.sub(' ', t[matchagainst]),
+                                      re.I)]
+
+            # find the best match: pull out the matching words, the match 
+            # with the least left is considered the best match    
+            min = 20
+            best = -1
+            for i,m in enumerate(matches):
+                stripped = self._ignore_chars.sub(' ', m[matchagainst]).strip()
+                for word in words:
+                    stripped = re.sub(r'\b'+word+r'\b', '', stripped, flags=re.I)\
+                                 .strip()
+                stripped = stripped.split() # to look at the number of words
+                if len(stripped) < min:
+                    min = len(stripped)
+                    best = i
+
+            if best >= 0:
+                out = matches[best]
+
+        if out and latest and 'deprecatedBy' in out and \
+           out['deprecatedBy'] in self.fulllu:
+            # replace deprecated term with latest
+            out = self.fulllu[out['deprecatedBy']]
+
+        if out:
+            out = self.TaxonomyTerm(out, self.data)
+        return out
+
+    class TaxonomyTerm(object):
+        """
+        a vocabulary term from the taxonomy
+        """
+        @classmethod
+        def make_full_term(cls, definition):
+            out = definition['term']
+            if 'parent' in definition:
+                out = "{0}: {1}".format(definition['parent'], out)
+            return out
+
+        def __init__(self, definition, taxonomy):
+            self.defn = definition
+            self.tax = taxonomy
+
+        def __str__(self):
+            if 'fullterm' in self.defn:
+                return self.defn['fullterm']
+            return self.make_full_term(self.defn)
+
+        def as_topic(self):
+            """
+            return a NERDm topic node for this term
+            :rtype dict:  the NERDm topic node
+            """
+            return OrderedDict([("@type", "Concept"), ("scheme", self.tax['@id']),
+                                ("tag", str(self))])
+
+                              
+                
+            

--- a/python/nistoar/nerdm/tests/test_taxonomy.py
+++ b/python/nistoar/nerdm/tests/test_taxonomy.py
@@ -1,0 +1,78 @@
+import unittest, pdb, os, json
+from collections import OrderedDict
+
+import nistoar.nerdm.taxonomy as taxon
+
+mddir = os.path.dirname(os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.abspath(os.path.dirname(__file__))))))
+schemadir = os.path.join(mddir, "model")
+
+
+class TestResearchTopicsTaxonomy(unittest.TestCase):
+
+    def setUp(self):
+        self.tax = taxon.ResearchTopicsTaxonomy.from_schema_dir(schemadir)
+
+    def test_ctor(self):
+        self.assertEqual(self.tax.data['version'], "1.1")
+        self.assertIsNotNone(self.tax.taillu)
+        self.assertIsNotNone(self.tax.fulllu)
+        self.assertIn('Bioscience', self.tax.taillu)
+        self.assertIn('Bioscience', self.tax.fulllu)
+        self.assertIn('Biomaterials', self.tax.taillu)
+        self.assertNotIn('Biomaterials', self.tax.fulllu)
+        self.assertNotIn('Bioscience: Biomaterials', self.tax.taillu)
+        self.assertIn('Bioscience: Biomaterials', self.tax.fulllu)
+
+    def test_match_theme_exactly(self):
+        term = self.tax.match_theme("Chemistry", False)
+        self.assertEqual(term.defn['term'], "Chemistry")
+        self.assertEqual(str(term), "Chemistry")
+
+        term = self.tax.match_theme("Biomaterials", False)
+        self.assertEqual(term.defn['term'], "Biomaterials")
+        self.assertEqual(str(term), "Bioscience: Biomaterials")
+
+        term = self.tax.match_theme("Ground", False)
+        self.assertEqual(term.defn['term'], "Ground")
+        self.assertEqual(str(term), "Public Safety: Response robots: Ground")
+
+        term = self.tax.match_theme("Response robots", False)
+        self.assertEqual(term.defn['term'], "Response robots")
+        self.assertEqual(str(term), "Public Safety: Response robots")
+
+    def test_match_theme_caseinsen(self):
+        term = self.tax.match_theme("buildings and construction", False)
+        self.assertEqual(term.defn['term'], "Buildings and Construction")
+
+        term = self.tax.match_theme("sustainable buildings", False)
+        self.assertEqual(term.defn['term'], "Sustainable buildings")
+        self.assertEqual(str(term), "Buildings and Construction: Sustainable buildings")
+
+    def test_match_theme_deprecated(self):
+        term = self.tax.match_theme("Internet of Things", False)
+        self.assertEqual(term.defn['term'], "Internet of Things")
+
+        term = self.tax.match_theme("Internet of Things", True)
+        self.assertEqual(term.defn['term'], "Internet of Things (IoT)")
+
+        term = self.tax.match_theme("internet of things")
+        self.assertEqual(term.defn['term'], "Internet of Things (IoT)")
+
+    def test_match_theme_words(self):
+        term = self.tax.match_theme("Materials: Concrete and Cement", False)
+        self.assertEqual(term.defn['term'], "Concrete/cement")
+
+        term = self.tax.match_theme("Biological Nuclear Explosives", False)
+        self.assertEqual(term.defn['term'], "Chemical/Biological/Radiological/Nuclear/Explosives (CBRNE)")
+
+    def test_as_topic(self):
+        term = self.tax.match_theme("Biomaterials", False)
+        topic = term.as_topic()
+        self.assertEqual(topic['@type'], "Concept")
+        self.assertEqual(topic['scheme'], "https://www.nist.gov/od/dm/nist-themes/v1.1")
+        self.assertEqual(topic['tag'], "Bioscience: Biomaterials")
+        
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/python/nistoar/nerdm/tests/test_taxonomy.py
+++ b/python/nistoar/nerdm/tests/test_taxonomy.py
@@ -70,7 +70,7 @@ class TestResearchTopicsTaxonomy(unittest.TestCase):
         term = self.tax.match_theme("Biomaterials", False)
         topic = term.as_topic()
         self.assertEqual(topic['@type'], "Concept")
-        self.assertEqual(topic['scheme'], "https://www.nist.gov/od/dm/nist-themes/v1.1")
+        self.assertEqual(topic['scheme'], "https://data.nist.gov/od/dm/nist-themes/v1.1")
         self.assertEqual(topic['tag'], "Bioscience: Biomaterials")
         
         

--- a/python/nistoar/rmm/mongo/taxon.py
+++ b/python/nistoar/rmm/mongo/taxon.py
@@ -47,7 +47,8 @@ class TaxonomyLoader(Loader):
         if len(termdata) > 1:
             id = None
         for term in termdata:
-            results = self.load_obj(term, validate, results, id)
+            if not term.get('deprecatedSince'):
+                results = self.load_obj(term, validate, results, id)
 
         return results
 

--- a/scripts/test_pdl2resources.py
+++ b/scripts/test_pdl2resources.py
@@ -2,7 +2,7 @@
 #
 from __future__ import print_function
 
-import os, pdb, sys, shutil
+import os, pdb, sys, shutil, json
 import unittest as test
 import ejsonschema as ejs
 
@@ -57,6 +57,16 @@ class TestConvert(test.TestCase):
             else:
                 sys.stderr.write(".")
                 passed += 1
+
+            with open(nf) as fd:
+                nerd = json.load(fd)
+            if 'theme' in nerd:
+                self.assertEqual(len(nerd['topic']), len(nerd['theme']))
+            if nerd['ediid'] == 'EBC9DB05EDEE5B0EE043065706812DF85':
+                self.assertIn('theme', nerd)
+                self.assertEqual(nerd['theme'][0], "Physics: Spectroscopy")
+                self.assertEqual(nerd['topic'][0]['tag'], "Physics: Spectroscopy")
+                self.assertTrue(all([':' in t for t in nerd['theme']]))
 
         sys.stderr.write("\nValidated {0} files".format(str(passed)))
         self.assertEquals(len(failed), 0,


### PR DESCRIPTION
This PR addresses ticket [ODD-859](http://mml.nist.gov:8080/browse/ODD-859) which reported that themes that users selected in MIDAS were not appearing as research themes on the landing page; further, many records were showing in the SDP search results as having the research themes as "unspecified".  

Themes are handled in a special way in the PDR publishing system because in the original, pre-PDR POD records, full taxonomy terms were not be properly specified: only the lowest (most-specific) term was being set.  For example, "Glycomics" would be specified rather than "Bioscience: Glycomics".  (This means in the former case, the record would not match a search for "Bioscience".)  Special code was put into the PDR publishing code to detect this error and replace the theme term with its fully specified term.  However, this code was only applied to records ingest from the original PDL; it was not getting applied to new submissions via MIDAS.  This produced a  NERDm record with an uncorrected `theme` property an empty `topic` property (which is used by the SDP and the landing page).  This PR applies the special theme handling to new submissions from MIDAS.

## Review and Testing

Review and Testing of this PR should be conducted via the accompanying [oar-pdr PR#134](https://github.com/usnistgov/oar-pdr/pull/134).  

