### PR TITLE
make description searchable

### DIFF
--- a/model/nerdm-fields-help.json
+++ b/model/nerdm-fields-help.json
@@ -116,7 +116,7 @@
         "name": "description",
         "type": "string",
         "label": "Resource Description",
-        "tags": [ "filterable" ],
+        "tags": [ "searchable", "filterable" ],
         "tips": {
             "search": "A summary of what this resource is about"
         }


### PR DESCRIPTION
SDP was not supporting `description` as a search key, although it is supported by the RMM API.  This was traced to a configuration error in a data file included in the oar-metadata repo.  This PR fixes this limitation by marking the `description` field as `searchable` (in addition to `filterable`).  

Note that for this to take effect on a system where the database is not recreated from scratch, the fields collection must be emptied and reloaded manually.  
