### PR TITLE
Remove topic and keyword from filterable list

### DIFF
--- a/model/nerdm-fields-help.json
+++ b/model/nerdm-fields-help.json
@@ -126,7 +126,7 @@
         "type": "array",
         "item_type": "string",
         "label": "Subject keywords",
-        "tags": [ "searchable", "filterable" ],
+        "tags": [ "searchable" ],
         "tips": {
             "search": "keywords that describe what this resource is about"
         }
@@ -144,7 +144,7 @@
         "name": "topic.tag",
         "type": "str",
         "label": "Research Topic",
-        "tags": [ "searchable", "filterable" ],
+        "tags": [ "searchable" ],
         "tips": {
             "search": "vocabulary terms that describe whatthis resource is about"
         }


### PR DESCRIPTION
This is part of the fixes for ODD-923:  Customize View Sorting.

The fix is to remove topic and keyword from filterable fields since they are array.

Once fixed, topic and keyword will be disappeared from the Sort dropdown list in Customize View (Search result page).