### PR TITLE
Fix affiliation encoding during NERDm conversion to DataCite

### DIFF
--- a/jq/nerdm2datacite.jq
+++ b/jq/nerdm2datacite.jq
@@ -109,7 +109,7 @@ def orcid2nameid:
 # Input:  NERDm affiliation object
 # Output: datacite affiliation string
 #
-def affil2simpleaffil:
+def affil2affilname:
     if .subunits then
         (.title + ", " + (.subunits | join(", ")))
     else
@@ -124,7 +124,7 @@ def affil2simpleaffil:
 #
 def affil2affil:
     {
-        affiliation: affil2simpleaffil,
+        name: affil2affilname,
         affiliationIdentifier: (
             if (.["@id"]|not) and .title == "NIST" then "grid:NIST" else .["@id"] end
         ),
@@ -137,7 +137,7 @@ def affil2affil:
         (.affiliationIdentifier = (.affiliationIdentifier|sub("ror:";"https://ror.org/"))|
          .affiliationIdentifierScheme = "ROR")
     elif (.affiliationIdentifer == "grid.94225.38" or
-          (.affiliation | contains("National Institute of Standards and Technology")) or
+          (.name | contains("National Institute of Standards and Technology")) or
           (.affiliationIdentifier == "grid:NIST"))
     then
         (.affiliationIdentifier = "https://ror.org/05xpvk416" |

--- a/jq/tests/test_nerdm2datacite.jqt
+++ b/jq/tests/test_nerdm2datacite.jqt
@@ -111,23 +111,23 @@ include "nerdm2datacite"; orcid2nameid
 { "nameIdentifier": "https://orcid.org/0000-0000-0000-0000", "nameIdentifierScheme": "ORCID", "schemeURI": "https://orcid.org" }
 
 #--------------
-# testing affil2simpleaffil
+# testing affil2affilname
 #
-include "nerdm2datacite"; affil2simpleaffil
+include "nerdm2datacite"; affil2affilname
 { "title": "NIST" }
 "NIST"
 
 #--------------
-# testing affil2simpleaffil
+# testing affil2affilname
 #
-include "nerdm2datacite"; affil2simpleaffil
+include "nerdm2datacite"; affil2affilname
 { "title": "NIST", "subunits": ["MML", "ODI"] }
 "NIST, MML, ODI"
 
 #--------------
-# testing affil2simpleaffil
+# testing affil2affilname
 #
-include "nerdm2datacite"; affil2simpleaffil
+include "nerdm2datacite"; affil2affilname
 { "title": "NIST", "subunits": ["MML"], "@id": "grid:NIST" }
 "NIST, MML"
 
@@ -136,77 +136,77 @@ include "nerdm2datacite"; affil2simpleaffil
 #
 include "nerdm2datacite"; affil2affil
 { "title": "MML", "subunits": ["ODI"], "@id": "sdorg:NIST" }
-{ "affiliation": "MML, ODI" }
+{ "name": "MML, ODI" }
 
 #--------------
 # testing affil2affil
 #
 include "nerdm2datacite"; affil2affil
 { "title": "NIST/NBS" }
-{ "affiliation": "NIST/NBS" }
+{ "name": "NIST/NBS" }
 
 #--------------
 # testing affil2affil
 #
 include "nerdm2datacite"; affil2affil
 { "title": "NREL", "@id": "grid:99999.22" }
-{ "affiliation": "NREL", "affiliationIdentifier": "grid:99999.22", "affiliationIdentifierScheme": "GRID" }
+{ "name": "NREL", "affiliationIdentifier": "grid:99999.22", "affiliationIdentifierScheme": "GRID" }
 
 #--------------
 # testing affil2affil
 #
 include "nerdm2datacite"; affil2affil
 { "title": "NIST" }
-{ "affiliation": "NIST", "affiliationIdentifier": "https://ror.org/05xpvk416", "affiliationIdentifierScheme": "ROR"  }
+{ "name": "NIST", "affiliationIdentifier": "https://ror.org/05xpvk416", "affiliationIdentifierScheme": "ROR"  }
 
 #--------------
 # testing affil2affil
 #
 include "nerdm2datacite"; affil2affil
 { "title": "NIST/NBS", "@id": "grid:NIST" }
-{ "affiliation": "NIST/NBS", "affiliationIdentifier": "https://ror.org/05xpvk416", "affiliationIdentifierScheme": "ROR"  }
+{ "name": "NIST/NBS", "affiliationIdentifier": "https://ror.org/05xpvk416", "affiliationIdentifierScheme": "ROR"  }
 
 #--------------
 # testing affils2affils
 #
 include "nerdm2datacite"; affils2affils
 [{ "title": "NREL" }]
-[{ "affiliation": "NREL" }]
+[{ "name": "NREL" }]
 
 #--------------
 # testing affils2affils
 #
 include "nerdm2datacite"; affils2affils
 [{ "title": "NIST", "subunits": ["MML"], "@id": "grid:NIST" }, { "title": "NIST/NBS", "subunits": ["MML"], "@id": "sdorg:NIST" }, { "title": "NIST", "@id": "grid.9999.33" }]
-[{ "affiliation": "NIST, MML", "affiliationIdentifier": "https://ror.org/05xpvk416", "affiliationIdentifierScheme": "ROR" }, { "affiliation": "NIST/NBS, MML" }, { "affiliation": "NIST", "affiliationIdentifier": "grid.9999.33", "affiliationIdentifierScheme": "GRID" }]
+[{ "name": "NIST, MML", "affiliationIdentifier": "https://ror.org/05xpvk416", "affiliationIdentifierScheme": "ROR" }, { "name": "NIST/NBS, MML" }, { "name": "NIST", "affiliationIdentifier": "grid.9999.33", "affiliationIdentifierScheme": "GRID" }]
 
 #--------------
 # testing author2creator
 #
 include "nerdm2datacite"; author2creator
 { "fn": "M.W. Chase, Jr.", "givenName": "M.", "middleName": "W.", "familyName": "Chase", "affiliation": [{ "@type": [ "org:Organization" ], "title": "National Institute of Standards and Technology (NIST)", "@id": "sdporg:NIST" }], "proxyFor": "sdpperson:Chase-MW" }
-{ "name": "Chase, M. W.", "nameType": "Personal", "givenName": "M. W.", "familyName": "Chase", "affiliation": [{ "affiliation": "National Institute of Standards and Technology (NIST)", "affiliationIdentifier": "https://ror.org/05xpvk416", "affiliationIdentifierScheme": "ROR" }]}
+{ "name": "Chase, M. W.", "nameType": "Personal", "givenName": "M. W.", "familyName": "Chase", "affiliation": [{ "name": "National Institute of Standards and Technology (NIST)", "affiliationIdentifier": "https://ror.org/05xpvk416", "affiliationIdentifierScheme": "ROR" }]}
 
 #--------------
 # testing author2creator
 #
 include "nerdm2datacite"; author2creator
 { "fn": "M.W. Chase, Jr.", "givenName": "M.", "middleName": "W.", "familyName": "Chase", "affiliation": [{ "@type": [ "org:Organization" ], "title": "National Institute of Standards and Technology (NIST)", "@id": "sdporg:NIST" }], "proxyFor": "sdpperson:Chase-MW" }
-{ "name": "Chase, M. W.", "nameType": "Personal", "givenName": "M. W.", "familyName": "Chase", "affiliation": [{ "affiliation": "National Institute of Standards and Technology (NIST)", "affiliationIdentifier": "https://ror.org/05xpvk416", "affiliationIdentifierScheme": "ROR" }]}
+{ "name": "Chase, M. W.", "nameType": "Personal", "givenName": "M. W.", "familyName": "Chase", "affiliation": [{ "name": "National Institute of Standards and Technology (NIST)", "affiliationIdentifier": "https://ror.org/05xpvk416", "affiliationIdentifierScheme": "ROR" }]}
 
 #--------------
 # testing author2creator
 #
 include "nerdm2datacite"; author2creator
 { "fn": "C.A. Davies", "givenName": "C.", "middleName": "A.", "familyName": "Davies", "affiliation": [{ "@type": [ "org:Organization" ], "title": "National Institute of Standards and Technology (NIST)", "@id": "grid:NIST", "subunits": ["PML"], "proxyFor": "sdpperson:Davies-CA" }]}
-{ "name": "Davies, C. A.", "nameType": "Personal", "givenName": "C. A.", "familyName": "Davies", "affiliation": [{ "affiliation": "National Institute of Standards and Technology (NIST), PML", "affiliationIdentifier": "https://ror.org/05xpvk416", "affiliationIdentifierScheme": "ROR" }]}
+{ "name": "Davies, C. A.", "nameType": "Personal", "givenName": "C. A.", "familyName": "Davies", "affiliation": [{ "name": "National Institute of Standards and Technology (NIST), PML", "affiliationIdentifier": "https://ror.org/05xpvk416", "affiliationIdentifierScheme": "ROR" }]}
 
 #--------------
 # testing author2creator
 #
 include "nerdm2datacite"; author2creator
 { "fn": "C.A. Davies", "givenName": "C.", "middleName": "A.", "affiliation": [{ "@type": [ "org:Organization" ], "title": "National Institute of Standards and Technology (NIST)", "@id": "grid:NIST", "subunits": ["PML"], "proxyFor": "sdpperson:Davies-CA" }]}
-{ "name": "C.A. Davies", "nameType": "Personal", "givenName": "C. A.", "affiliation": [{ "affiliation": "National Institute of Standards and Technology (NIST), PML", "affiliationIdentifier": "https://ror.org/05xpvk416", "affiliationIdentifierScheme": "ROR" }]}
+{ "name": "C.A. Davies", "nameType": "Personal", "givenName": "C. A.", "affiliation": [{ "name": "National Institute of Standards and Technology (NIST), PML", "affiliationIdentifier": "https://ror.org/05xpvk416", "affiliationIdentifierScheme": "ROR" }]}
 
 #--------------
 # testing make_titles


### PR DESCRIPTION
The author's affiliation--namely, the affiliation's title--was not being encoded correctly when a NERDm record was converted to DataCite format; consequently, it was not getting saved when the record was submitted to the DataCite server.  This PR corrects this issue by changing the DataCite property name (within the full affiliation object) from `affiliation` to `name`.
