### PR TITLE
Support proper reference labeling and display in landing page

### DIFF
--- a/docker/jqfromsrc/Dockerfile
+++ b/docker/jqfromsrc/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 WORKDIR /root
 RUN git clone http://github.com/stedolan/jq.git jq-dev && \
     cd jq-dev && \
-    git checkout 6306ac89667cf35f47ddc40aa0630546c57e387f && \
+    git checkout 80052e5275ae8c45b20411eecdd49c945a64a412 && \
     git submodule update --init && \
     autoreconf -fi && \
     ./configure --with-oniguruma=builtin && \

--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -25,7 +25,7 @@ def nerdm_schema:  "https://data.nist.gov/od/dm/nerdm-schema/v0.4#";
 
 # the base NERDm JSON schema namespace
 #
-def nerdm_pub_schema:  "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#";
+def nerdm_pub_schema:  "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#";
 
 # the NERDm context location
 #
@@ -230,7 +230,7 @@ def dist2download:
     .["filepath"] = ( .downloadURL | filepath ) |
     .["@type"] = [ "nrdp:DataFile", "nrdp:DownloadableFile", "dcat:Distribution" ] |
     .["@id"] = (. | componentID("cmps/")) |
-    .["_extensionSchemas"] = [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile" ] |
+    .["_extensionSchemas"] = [ nerdm_pub_schema + "/definitions/DataFile" ] |
     if .format then .format = { description: .format } else . end
 ;
 
@@ -244,7 +244,7 @@ def dist2checksum:
     .["filepath"] = ( .downloadURL | filepath ) |
     .["@type"] = [ "nrdp:ChecksumFile", "nrdp:DownloadableFile", "dcat:Distribution" ] |
     .["@id"] = (. | componentID("cmps/")) |
-    .["_extensionSchemas"] = [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/ChecksumFile" ] |
+    .["_extensionSchemas"] = [ nerdm_pub_schema + "/definitions/ChecksumFile" ] |
     .["mediaType"] = "text/plain" |
     .["algorithm"] = { "@type": "Thing", tag: (.filepath|extension) } |
     if .description then . else .["description"] = "SHA-256 checksum value for "+(.filepath|basename|remove_extension) end | 
@@ -284,7 +284,7 @@ def dist2inaccess:
 def dist2accesspage:
     .["@type"] = [ "nrdp:AccessPage", "dcat:Distribution" ] |
     .["@id"] = (. | componentID("#")) |
-    .["_extensionSchemas"] = [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/AccessPage" ] |
+    .["_extensionSchemas"] = [ nerdm_pub_schema + "/definitions/AccessPage" ] |
     if .format then .format = { description: .format } else . end
 ;
 

--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -23,9 +23,13 @@ include "urldecode";
 #
 def nerdm_schema:  "https://data.nist.gov/od/dm/nerdm-schema/v0.4#";
 
-# the base NERDm JSON schema namespace
+# the NERDm pub schema extension namespace
 #
 def nerdm_pub_schema:  "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#";
+
+# the NERDm bib schema extension namespace
+#
+def nerdm_bib_schema:  "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.4#";
 
 # the NERDm context location
 #
@@ -33,7 +37,7 @@ def nerdm_context: "https://data.nist.gov/od/dm/nerdm-pub-context.jsonld";
 
 # where the Datacite Document Reference types are defined
 #
-def dciteRefType: nerdm_schema + "/definitions/DCiteReference";
+def dciteRefType: nerdm_bib_schema + "/definitions/DCiteReference";
 
 # the resource identifier provided on the command line
 #

--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -21,7 +21,7 @@ include "urldecode";
 
 # the base NERDm JSON schema namespace
 #
-def nerdm_schema:  "https://data.nist.gov/od/dm/nerdm-schema/v0.3#";
+def nerdm_schema:  "https://data.nist.gov/od/dm/nerdm-schema/v0.4#";
 
 # the base NERDm JSON schema namespace
 #
@@ -174,7 +174,7 @@ def ansc_coll_paths:
 def cvtref:  {
     "@type": ["deo:BibliographicReference"],
     "@id": ("#ref:" + (. | urlpath | sub("^/"; ""))),
-    "refType": "IsReferencedBy",
+    "refType": "IsSupplementTo",
     "location": .,
     "_extensionSchemas": [ dciteRefType ]
 };

--- a/jq/tests/test_pod2nerdm.jqt
+++ b/jq/tests/test_pod2nerdm.jqt
@@ -10,7 +10,7 @@
 #
 include "pod2nerdm"; nerdm_schema
 null
-"https://data.nist.gov/od/dm/nerdm-schema/v0.3#"
+"https://data.nist.gov/od/dm/nerdm-schema/v0.4#"
 
 #--------------
 # testing nerdm_schema()
@@ -31,7 +31,7 @@ null
 #
 include "pod2nerdm"; dciteRefType
 null
-"https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/DCiteReference"
+"https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/DCiteReference"
 
 #--------------
 # testing resid()
@@ -91,7 +91,7 @@ include "pod2nerdm"; pdrLandingPageURL
 #
 include "pod2nerdm"; map(cvtref)
 [ "http://goob.net/doc1.txt", "https://goob.gov/doc2.txt" ]
-[{ "@type": ["deo:BibliographicReference"],"@id":"#ref:doc1.txt", "refType": "IsReferencedBy", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/DCiteReference" ], "location": "http://goob.net/doc1.txt"}, { "@type": ["deo:BibliographicReference"],"@id":"#ref:doc2.txt", "refType": "IsReferencedBy", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/DCiteReference" ], "location": "https://goob.gov/doc2.txt"}]
+[{ "@type": ["deo:BibliographicReference"],"@id":"#ref:doc1.txt", "refType": "IsSupplementTo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/DCiteReference" ], "location": "http://goob.net/doc1.txt"}, { "@type": ["deo:BibliographicReference"],"@id":"#ref:doc2.txt", "refType": "IsSupplementTo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/DCiteReference" ], "location": "https://goob.gov/doc2.txt"}]
 
 #---------------
 # testing filepath()

--- a/jq/tests/test_pod2nerdm.jqt
+++ b/jq/tests/test_pod2nerdm.jqt
@@ -31,7 +31,7 @@ null
 #
 include "pod2nerdm"; dciteRefType
 null
-"https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/DCiteReference"
+"https://data.nist.gov/od/dm/nerdm-schema/bib/v0.4#/definitions/DCiteReference"
 
 #--------------
 # testing resid()
@@ -91,7 +91,7 @@ include "pod2nerdm"; pdrLandingPageURL
 #
 include "pod2nerdm"; map(cvtref)
 [ "http://goob.net/doc1.txt", "https://goob.gov/doc2.txt" ]
-[{ "@type": ["deo:BibliographicReference"],"@id":"#ref:doc1.txt", "refType": "IsSupplementTo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/DCiteReference" ], "location": "http://goob.net/doc1.txt"}, { "@type": ["deo:BibliographicReference"],"@id":"#ref:doc2.txt", "refType": "IsSupplementTo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/DCiteReference" ], "location": "https://goob.gov/doc2.txt"}]
+[{ "@type": ["deo:BibliographicReference"],"@id":"#ref:doc1.txt", "refType": "IsSupplementTo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.4#/definitions/DCiteReference" ], "location": "http://goob.net/doc1.txt"}, { "@type": ["deo:BibliographicReference"],"@id":"#ref:doc2.txt", "refType": "IsSupplementTo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.4#/definitions/DCiteReference" ], "location": "https://goob.gov/doc2.txt"}]
 
 #---------------
 # testing filepath()

--- a/jq/tests/test_pod2nerdm.jqt
+++ b/jq/tests/test_pod2nerdm.jqt
@@ -17,7 +17,7 @@ null
 #
 include "pod2nerdm"; nerdm_pub_schema
 null
-"https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#"
+"https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#"
 
 #--------------
 # testing nerdm_context()
@@ -220,14 +220,14 @@ include "pod2nerdm"; map(componentID("#"))
 #
 include "pod2nerdm"; dist2download
 {"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json", "mediaType": "application/json","title": "Titanium Boride" }
-{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"]}
+{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"]}
 
 #--------------
 # testing dist2checksum()
 #
 include "pod2nerdm"; dist2checksum
 {"downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json.sha256", "title": "Checksum for srd13_B-101.json" }
-{"downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json.sha256","mediaType": "text/plain", "description": "SHA-256 checksum value for srd13_B-101.json", "title": "Checksum for srd13_B-101.json", "filepath":"srd13_B-101.json.sha256", "algorithm": {"@type": "Thing","tag": "sha256"},"@type": ["nrdp:ChecksumFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json.sha256","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/ChecksumFile"]}
+{"downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json.sha256","mediaType": "text/plain", "description": "SHA-256 checksum value for srd13_B-101.json", "title": "Checksum for srd13_B-101.json", "filepath":"srd13_B-101.json.sha256", "algorithm": {"@type": "Thing","tag": "sha256"},"@type": ["nrdp:ChecksumFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json.sha256","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/ChecksumFile"]}
 
 #--------------
 # testing dist2hidden()
@@ -248,7 +248,7 @@ include "pod2nerdm"; dist2inaccess
 #
 include "pod2nerdm"; dist2accesspage
 {"accessURL": "https://doi.org/10.18434/T42C7D","title": "A Library to Enable the Modeling of Optical Imaging of Finite Multi-Line Arrays"}
-{"accessURL": "https://doi.org/10.18434/T42C7D","title": "A Library to Enable the Modeling of Optical Imaging of Finite Multi-Line Arrays","@type": [ "nrdp:AccessPage", "dcat:Distribution" ],"@id":"#10.18434/T42C7D","_extensionSchemas":["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/AccessPage"]}
+{"accessURL": "https://doi.org/10.18434/T42C7D","title": "A Library to Enable the Modeling of Optical Imaging of Finite Multi-Line Arrays","@type": [ "nrdp:AccessPage", "dcat:Distribution" ],"@id":"#10.18434/T42C7D","_extensionSchemas":["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/AccessPage"]}
 
 #--------------
 # testing dist2comp()
@@ -267,7 +267,7 @@ include "pod2nerdm"; dist2comp
 #
 include "pod2nerdm"; dist2comp
 {"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json", "mediaType": "application/json","title": "Titanium Boride" }
-{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"]}
+{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"]}
 
 #--------------
 # testing dist2comp()
@@ -277,7 +277,7 @@ include "pod2nerdm"; dist2comp
 #
 include "pod2nerdm"; dist2comp
 {"accessURL": "http://www.nsrl.nist.gov/Downloads.htm","conformsTo": "http://www.nsrl.nist.gov/Documents/Data-Formats-of-the-NSRL-Reference-Data-Set-16.pdf","downloadURL": "http://www.nsrl.nist.gov/RDS/rds_2.50/RDS_250.iso","format": "ISO 9660 disk image","mediaType": "application/zip" }
-{"accessURL": "http://www.nsrl.nist.gov/Downloads.htm","conformsTo": "http://www.nsrl.nist.gov/Documents/Data-Formats-of-the-NSRL-Reference-Data-Set-16.pdf","downloadURL": "http://www.nsrl.nist.gov/RDS/rds_2.50/RDS_250.iso","format": { "description": "ISO 9660 disk image"},"mediaType": "application/zip", "filepath":"RDS_250.iso", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/RDS_250.iso","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"] }
+{"accessURL": "http://www.nsrl.nist.gov/Downloads.htm","conformsTo": "http://www.nsrl.nist.gov/Documents/Data-Formats-of-the-NSRL-Reference-Data-Set-16.pdf","downloadURL": "http://www.nsrl.nist.gov/RDS/rds_2.50/RDS_250.iso","format": { "description": "ISO 9660 disk image"},"mediaType": "application/zip", "filepath":"RDS_250.iso", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/RDS_250.iso","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"] }
 
 #--------------
 # testing dist2comp()
@@ -287,7 +287,7 @@ include "pod2nerdm"; dist2comp
 #
 include "pod2nerdm"; dist2comp
 {"accessURL": "http://webbook.nist.gov/chemistry/","description": "Landing page for the NIST Chemistry WebBook.","mediaType": "text/html"}
-{ "accessURL": "http://webbook.nist.gov/chemistry/","description": "Landing page for the NIST Chemistry WebBook.","mediaType": "text/html","@type": ["nrdp:AccessPage","dcat:Distribution"],"@id":"#chemistry/","_extensionSchemas":["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/AccessPage"]}
+{ "accessURL": "http://webbook.nist.gov/chemistry/","description": "Landing page for the NIST Chemistry WebBook.","mediaType": "text/html","@type": ["nrdp:AccessPage","dcat:Distribution"],"@id":"#chemistry/","_extensionSchemas":["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/AccessPage"]}
 
 # testing dist2comp()
 #
@@ -389,13 +389,13 @@ include "pod2nerdm"; select_comp_type("nrdp:Subcollection"; "foo/bar")
 #
 include "pod2nerdm"; create_subcoll_for
 "a/b/foo"
-{"@id": "cmps/a/b/foo", "@type": ["nrdp:Subcollection"], "filepath": "a/b/foo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/Subcollection" ]}
+{"@id": "cmps/a/b/foo", "@type": ["nrdp:Subcollection"], "filepath": "a/b/foo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/Subcollection" ]}
 
 # testing insert_subcoll_comps
 #
 include "pod2nerdm"; insert_subcoll_comps
 [{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
-[{"@id": "cmps/foo/bar", "@type": ["nrdp:Subcollection"], "filepath": "foo/bar", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/Subcollection" ]},{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
+[{"@id": "cmps/foo/bar", "@type": ["nrdp:Subcollection"], "filepath": "foo/bar", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/Subcollection" ]},{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
 
 
 

--- a/jq/tests/test_podds2resource.py
+++ b/jq/tests/test_podds2resource.py
@@ -3,7 +3,7 @@
 import os, unittest, json, subprocess as subproc, types, pdb
 import ejsonschema as ejs
 
-nerdm = "https://data.nist.gov/od/dm/nerdm-schema/v0.3#"
+nerdm = "https://data.nist.gov/od/dm/nerdm-schema/v0.4#"
 nerdmpub = "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#"
 datadir = os.path.join(os.path.dirname(__file__), "data")
 janaffile = os.path.join(datadir, "janaf_pod.json")
@@ -29,7 +29,7 @@ class TestJanaf(unittest.TestCase):  #
                           
     def test_schema(self):
         self.assertEquals(self.out['_schema'],
-                          "https://data.nist.gov/od/dm/nerdm-schema/v0.3#")
+                          "https://data.nist.gov/od/dm/nerdm-schema/v0.4#")
     def test_extsch(self):
         
         exts = self.out['_extensionSchemas']
@@ -101,7 +101,7 @@ class TestJanaf(unittest.TestCase):  #
         self.assertIsInstance(refs[0]['@type'], list)
         self.assertIsInstance(refs[0]['@type'][0], types.StringTypes)
         self.assertEquals(refs[0]['@type'], ["deo:BibliographicReference"])
-        self.assertEquals(refs[0]['refType'], "IsReferencedBy")
+        self.assertEquals(refs[0]['refType'], "IsSupplementTo")
         self.assertEquals(refs[0]['location'],
                           "http://www.nist.gov/data/PDFfiles/jpcrdS1V14.pdf")
 
@@ -142,7 +142,7 @@ class TestCORR(unittest.TestCase):  #
                           
     def test_schema(self):
         self.assertEquals(self.out['_schema'],
-                          "https://data.nist.gov/od/dm/nerdm-schema/v0.3#")
+                          "https://data.nist.gov/od/dm/nerdm-schema/v0.4#")
     def test_extsch(self):
         
         exts = self.out['_extensionSchemas']

--- a/jq/tests/test_podds2resource.py
+++ b/jq/tests/test_podds2resource.py
@@ -5,6 +5,7 @@ import ejsonschema as ejs
 
 nerdm = "https://data.nist.gov/od/dm/nerdm-schema/v0.4#"
 nerdmpub = "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#"
+nerdmbib = "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.4#"
 datadir = os.path.join(os.path.dirname(__file__), "data")
 janaffile = os.path.join(datadir, "janaf_pod.json")
 corrfile =  os.path.join(datadir, "CORR-DATA.json")
@@ -107,7 +108,7 @@ class TestJanaf(unittest.TestCase):  #
 
         exts = refs[0]['_extensionSchemas']
         self.assertEquals(len(exts), 1)
-        self.assertIn(nerdm+"/definitions/DCiteReference", exts)
+        self.assertIn(nerdmbib+"/definitions/DCiteReference", exts)
 
     def test_hierarchy(self):
         self.assertIn("dataHierarchy", self.out,

--- a/jq/tests/test_podds2resource.py
+++ b/jq/tests/test_podds2resource.py
@@ -4,7 +4,7 @@ import os, unittest, json, subprocess as subproc, types, pdb
 import ejsonschema as ejs
 
 nerdm = "https://data.nist.gov/od/dm/nerdm-schema/v0.4#"
-nerdmpub = "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#"
+nerdmpub = "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#"
 datadir = os.path.join(os.path.dirname(__file__), "data")
 janaffile = os.path.join(datadir, "janaf_pod.json")
 corrfile =  os.path.join(datadir, "CORR-DATA.json")

--- a/model/examples/hitsc.json
+++ b/model/examples/hitsc.json
@@ -1,7 +1,7 @@
 {
     "@context": "https://data.nist.gov/od/dm/nerdm-pub-context.jsonld",
-    "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.3#",
-    "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataPublication" ],
+    "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#",
+    "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataPublication" ],
 
     "@type": [ "nrdp:Database", "nrdp:SRD", "nrdp:PublishedDataResource" ],
     "@id": "ark:/88434/sdp0fjspek353",
@@ -48,12 +48,12 @@
     ],
     "references": [
         {
-            "@type": "deo:BibliographicReference",
+            "@type": [ "npg:Article", "schema:Article" ],
             "refType": "IsDocumentedBy",
             "label": "User Manual",
             "location": "https://srdata.nist.gov/CeramicDataPortal/Manual/HtsHelper",
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/DCiteReference"
+                "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.4#/definitions/DCiteReference"
             ]
         }
     ],

--- a/model/examples/janaf.json
+++ b/model/examples/janaf.json
@@ -1,7 +1,7 @@
 {
     "@context": "https://data.nist.gov/od/dm/nerdm-pub-context.jsonld",
-    "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.3#",
-    "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataPublication" ],
+    "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#",
+    "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataPublication" ],
 
     "@type": [ "nrd:SRD", "nrdp:DataPublication", "nrdp:PublicDataResource" ],
     "@id": "ark:/88434/sdp0fjspek351",
@@ -109,21 +109,21 @@
     ],
     "references": [
         {
-            "@type": "deo:BibliographicReference",
+            "@type": [ "schema:Book" ],
             "refType": "IsDocumentedBy",
             "label": "JPCRD Monograph: NIST-JANAF Thermochemical Tables, Pt. 1 (AL-C",
             "location": "http://kinetics.nist.gov/janaf/pdf/JANAF-FourthEd-1998-1Vol1-Intro.pdf",
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/DCiteReference"
+                "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.4#/definitions/DCiteReference"
             ]
         },
         {
-            "@type": "deo:BibliographicReference",
+            "@type": [ "schema:Book" ],
             "refType": "IsDocumentedBy",
             "label": "JPCRD Monograph: NIST-JANAF Thermochemical Tables, Pt. 2 (Cr-Zr)",
             "location": "http://kinetics.nist.gov/janaf/pdf/JANAF-FourthEd-1998-1Vol2-Intro.pdf",
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/DCiteReference"
+                "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.4#/definitions/DCiteReference"
             ]
         }
     ],
@@ -473,7 +473,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-101.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-101.json",
@@ -484,7 +484,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-102.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-102.json",
@@ -495,7 +495,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-103.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-103.json",
@@ -506,7 +506,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-104.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-104.json",
@@ -517,7 +517,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-105.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-105.json",
@@ -528,7 +528,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-106.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-106.json",
@@ -539,7 +539,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-107.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-107.json",
@@ -550,7 +550,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-108.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-108.json",
@@ -561,7 +561,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-109.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-109.json",
@@ -572,7 +572,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-110.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-110.json",
@@ -583,7 +583,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-111.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-111.json",
@@ -594,7 +594,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-112.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-112.json",
@@ -605,7 +605,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-113.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-113.json",
@@ -616,7 +616,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-114.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-114.json",
@@ -627,7 +627,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-115.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-115.json",
@@ -638,7 +638,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-116.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-116.json",
@@ -649,7 +649,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-117.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-117.json",
@@ -660,7 +660,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-118.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-118.json",
@@ -671,7 +671,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-119.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-119.json",
@@ -682,7 +682,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-120.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-120.json",
@@ -693,7 +693,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-121.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-121.json",
@@ -704,7 +704,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-122.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-122.json",
@@ -715,7 +715,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-123.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-123.json",
@@ -726,7 +726,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-124.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-124.json",
@@ -737,11 +737,11 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-125.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-125.json",
@@ -752,11 +752,11 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-126.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-126.json",
@@ -767,7 +767,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-127.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-127.json",
@@ -778,7 +778,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-128.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-128.json",
@@ -789,7 +789,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-129.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-129.json",
@@ -800,7 +800,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-130.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-130.json",
@@ -811,7 +811,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-131.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-131.json",
@@ -822,7 +822,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-132.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-132.json",
@@ -833,7 +833,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-133.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-133.json",
@@ -844,7 +844,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-134.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-134.json",
@@ -855,7 +855,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-135.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-135.json",
@@ -866,7 +866,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-136.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-136.json",
@@ -877,7 +877,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-137.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-137.json",
@@ -888,7 +888,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-138.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-138.json",
@@ -899,7 +899,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-139.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-139.json",
@@ -910,7 +910,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_janaf-zipfile.zip",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_janaf-zipfile.zip",
@@ -921,7 +921,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
 
             "filepath": "srd13_janaf.species.json",
@@ -933,7 +933,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-001.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-001.json",
@@ -944,7 +944,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-002.json",
@@ -955,7 +955,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-003.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-003.json",
@@ -966,7 +966,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-004.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-004.json",
@@ -977,7 +977,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-005.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-005.json",
@@ -988,7 +988,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-006.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-006.json",
@@ -999,7 +999,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-007.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-007.json",
@@ -1010,7 +1010,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-008.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-008.json",
@@ -1021,7 +1021,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-009.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-009.json",
@@ -1032,7 +1032,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-010.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-010.json",
@@ -1043,7 +1043,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-011.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-011.json",
@@ -1054,7 +1054,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-012.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-012.json",
@@ -1065,7 +1065,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-013.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-013.json",
@@ -1076,7 +1076,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-014.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-014.json",
@@ -1087,7 +1087,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-015.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-015.json",
@@ -1098,7 +1098,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-016.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-016.json",
@@ -1109,7 +1109,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-017.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-017.json",
@@ -1120,7 +1120,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-018.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-018.json",
@@ -1131,7 +1131,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-019.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-019.json",
@@ -1142,7 +1142,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-020.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-020.json",
@@ -1153,7 +1153,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-021.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-021.json",
@@ -1164,7 +1164,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-022.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-022.json",
@@ -1175,7 +1175,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-023.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-023.json",
@@ -1186,7 +1186,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-024.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-024.json",
@@ -1197,7 +1197,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-025.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-025.json",
@@ -1208,7 +1208,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-026.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-026.json",
@@ -1219,7 +1219,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-027.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-027.json",
@@ -1230,7 +1230,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-028.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-028.json",
@@ -1241,7 +1241,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-029.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-029.json",
@@ -1252,7 +1252,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-030.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-030.json",
@@ -1263,7 +1263,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-031.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-031.json",
@@ -1274,7 +1274,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-032.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-032.json",
@@ -1285,7 +1285,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-033.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-033.json",
@@ -1296,7 +1296,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-034.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-034.json",
@@ -1307,7 +1307,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-035.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-035.json",
@@ -1318,7 +1318,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-036.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-036.json",
@@ -1329,7 +1329,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-037.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-037.json",
@@ -1340,7 +1340,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-038.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-038.json",
@@ -1351,7 +1351,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-039.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-039.json",
@@ -1362,7 +1362,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-040.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-040.json",
@@ -1373,7 +1373,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-041.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-041.json",
@@ -1384,7 +1384,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-042.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-042.json",
@@ -1395,7 +1395,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-043.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-043.json",
@@ -1406,7 +1406,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-044.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-044.json",
@@ -1417,7 +1417,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-045.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-045.json",
@@ -1428,7 +1428,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-046.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-046.json",
@@ -1439,7 +1439,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-047.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-047.json",
@@ -1450,7 +1450,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-048.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-048.json",
@@ -1461,7 +1461,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-049.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-049.json",
@@ -1472,7 +1472,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-050.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-050.json",
@@ -1483,7 +1483,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-051.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-051.json",
@@ -1494,7 +1494,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-052.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-052.json",
@@ -1505,7 +1505,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-053.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-053.json",
@@ -1516,7 +1516,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-054.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-054.json",
@@ -1527,7 +1527,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-055.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-055.json",
@@ -1538,7 +1538,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-056.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-056.json",
@@ -1549,7 +1549,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-057.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-057.json",
@@ -1560,7 +1560,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-058.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-058.json",
@@ -1571,7 +1571,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-059.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-059.json",
@@ -1582,7 +1582,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-060.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-060.json",
@@ -1593,7 +1593,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-061.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-061.json",
@@ -1604,7 +1604,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-062.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-062.json",
@@ -1615,7 +1615,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-063.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-063.json",
@@ -1626,7 +1626,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-064.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-064.json",
@@ -1637,7 +1637,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-065.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-065.json",
@@ -1648,7 +1648,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-066.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-066.json",
@@ -1659,7 +1659,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-067.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-067.json",
@@ -1670,7 +1670,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-068.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-068.json",
@@ -1681,7 +1681,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-069.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-069.json",
@@ -1692,7 +1692,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-070.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-070.json",
@@ -1703,7 +1703,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-071.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-071.json",
@@ -1714,7 +1714,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-072.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-072.json",
@@ -1725,7 +1725,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-073.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-073.json",
@@ -1736,7 +1736,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-074.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-074.json",
@@ -1747,7 +1747,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-075.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-075.json",
@@ -1758,7 +1758,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-076.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-076.json",
@@ -1769,7 +1769,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-077.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-077.json",
@@ -1780,7 +1780,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-078.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-078.json",
@@ -1791,7 +1791,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-079.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-079.json",
@@ -1802,7 +1802,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-080.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-080.json",
@@ -1813,7 +1813,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-081.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-081.json",
@@ -1824,7 +1824,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-082.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-082.json",
@@ -1835,7 +1835,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-083.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-083.json",
@@ -1846,7 +1846,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-084.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-084.json",
@@ -1857,7 +1857,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-085.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-085.json",
@@ -1868,7 +1868,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Rn-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Rn-002.json",
@@ -1879,7 +1879,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-086.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-086.json",
@@ -1890,7 +1890,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-087.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-087.json",
@@ -1901,7 +1901,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-088.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-088.json",
@@ -1912,7 +1912,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-089.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-089.json",
@@ -1923,7 +1923,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-090.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-090.json",
@@ -1934,7 +1934,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-091.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-091.json",
@@ -1945,7 +1945,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-092.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-092.json",
@@ -1956,7 +1956,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-093.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-093.json",
@@ -1967,7 +1967,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-094.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-094.json",
@@ -1978,7 +1978,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-095.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-095.json",
@@ -1989,7 +1989,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-096.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-096.json",
@@ -2000,7 +2000,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-097.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-097.json",
@@ -2011,7 +2011,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-098.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-098.json",
@@ -2022,7 +2022,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-099.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-099.json",
@@ -2033,7 +2033,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-100.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-100.json",
@@ -2044,7 +2044,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-101.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-101.json",
@@ -2055,7 +2055,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-102.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-102.json",
@@ -2066,7 +2066,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-103.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-103.json",
@@ -2077,7 +2077,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-104.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-104.json",
@@ -2088,7 +2088,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-105.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-105.json",
@@ -2099,7 +2099,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-106.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-106.json",
@@ -2110,7 +2110,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-107.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-107.json",
@@ -2121,7 +2121,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-108.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-108.json",
@@ -2132,7 +2132,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-109.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-109.json",
@@ -2143,7 +2143,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-110.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-110.json",
@@ -2154,7 +2154,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-111.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-111.json",
@@ -2165,7 +2165,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Al-112.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Al-112.json",
@@ -2176,7 +2176,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Ar-001.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ar-001.json",
@@ -2187,7 +2187,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Ar-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ar-002.json",
@@ -2198,7 +2198,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-001.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-001.json",
@@ -2209,7 +2209,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-002.json",
@@ -2220,7 +2220,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-003.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-003.json",
@@ -2231,7 +2231,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-004.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-004.json",
@@ -2242,7 +2242,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-005.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-005.json",
@@ -2253,7 +2253,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-006.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-006.json",
@@ -2264,7 +2264,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-007.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-007.json",
@@ -2275,7 +2275,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-008.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-008.json",
@@ -2286,7 +2286,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-009.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-009.json",
@@ -2297,7 +2297,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-010.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-010.json",
@@ -2308,7 +2308,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-011.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-011.json",
@@ -2319,7 +2319,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-012.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-012.json",
@@ -2330,7 +2330,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-013.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-013.json",
@@ -2341,7 +2341,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-014.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-014.json",
@@ -2352,7 +2352,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-015.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-015.json",
@@ -2363,7 +2363,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-016.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-016.json",
@@ -2374,7 +2374,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-017.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-017.json",
@@ -2385,7 +2385,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-018.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-018.json",
@@ -2396,7 +2396,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-019.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-019.json",
@@ -2407,7 +2407,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-020.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-020.json",
@@ -2418,7 +2418,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-021.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-021.json",
@@ -2429,7 +2429,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-022.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-022.json",
@@ -2440,7 +2440,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-023.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-023.json",
@@ -2451,7 +2451,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-024.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-024.json",
@@ -2462,7 +2462,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-025.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-025.json",
@@ -2473,7 +2473,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-026.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-026.json",
@@ -2484,7 +2484,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-027.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-027.json",
@@ -2495,7 +2495,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-028.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-028.json",
@@ -2506,7 +2506,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-029.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-029.json",
@@ -2517,7 +2517,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-030.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-030.json",
@@ -2528,7 +2528,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-031.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-031.json",
@@ -2539,7 +2539,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-032.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-032.json",
@@ -2550,7 +2550,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-033.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-033.json",
@@ -2561,7 +2561,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-034.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-034.json",
@@ -2572,7 +2572,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-035.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-035.json",
@@ -2583,7 +2583,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-036.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-036.json",
@@ -2594,7 +2594,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-037.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-037.json",
@@ -2605,7 +2605,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-038.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-038.json",
@@ -2616,7 +2616,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-039.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-039.json",
@@ -2627,7 +2627,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-040.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-040.json",
@@ -2638,7 +2638,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-041.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-041.json",
@@ -2649,7 +2649,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-042.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-042.json",
@@ -2660,7 +2660,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-043.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-043.json",
@@ -2671,7 +2671,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-044.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-044.json",
@@ -2682,7 +2682,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-045.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-045.json",
@@ -2693,7 +2693,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-046.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-046.json",
@@ -2704,7 +2704,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-047.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-047.json",
@@ -2715,7 +2715,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-048.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-048.json",
@@ -2726,7 +2726,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-049.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-049.json",
@@ -2737,7 +2737,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-050.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-050.json",
@@ -2748,7 +2748,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-051.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-051.json",
@@ -2759,7 +2759,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-052.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-052.json",
@@ -2770,7 +2770,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-053.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-053.json",
@@ -2781,7 +2781,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-054.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-054.json",
@@ -2792,7 +2792,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-055.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-055.json",
@@ -2803,7 +2803,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-056.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-056.json",
@@ -2814,7 +2814,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-057.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-057.json",
@@ -2825,7 +2825,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-058.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-058.json",
@@ -2836,7 +2836,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-059.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-059.json",
@@ -2847,7 +2847,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-060.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-060.json",
@@ -2858,7 +2858,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-061.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-061.json",
@@ -2869,7 +2869,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-062.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-062.json",
@@ -2880,7 +2880,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-063.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-063.json",
@@ -2891,7 +2891,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-064.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-064.json",
@@ -2902,7 +2902,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-065.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-065.json",
@@ -2913,7 +2913,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-066.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-066.json",
@@ -2924,7 +2924,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-067.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-067.json",
@@ -2935,7 +2935,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-068.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-068.json",
@@ -2946,7 +2946,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-069.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-069.json",
@@ -2957,7 +2957,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-070.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-070.json",
@@ -2968,7 +2968,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-071.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-071.json",
@@ -2979,7 +2979,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-072.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-072.json",
@@ -2990,7 +2990,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-073.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-073.json",
@@ -3001,7 +3001,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-074.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-074.json",
@@ -3012,7 +3012,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-075.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-075.json",
@@ -3023,7 +3023,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-076.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-076.json",
@@ -3034,7 +3034,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-077.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-077.json",
@@ -3045,7 +3045,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-078.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-078.json",
@@ -3056,7 +3056,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-079.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-079.json",
@@ -3067,7 +3067,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-080.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-080.json",
@@ -3078,7 +3078,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-081.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-081.json",
@@ -3089,7 +3089,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-082.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-082.json",
@@ -3100,7 +3100,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-083.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-083.json",
@@ -3111,7 +3111,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-084.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-084.json",
@@ -3122,7 +3122,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-085.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-085.json",
@@ -3133,7 +3133,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-086.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-086.json",
@@ -3144,7 +3144,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-087.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-087.json",
@@ -3155,7 +3155,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-088.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-088.json",
@@ -3166,7 +3166,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-089.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-089.json",
@@ -3177,7 +3177,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-090.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-090.json",
@@ -3188,7 +3188,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-091.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-091.json",
@@ -3199,7 +3199,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-092.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-092.json",
@@ -3210,7 +3210,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-093.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-093.json",
@@ -3221,7 +3221,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-094.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-094.json",
@@ -3232,7 +3232,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-095.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-095.json",
@@ -3243,7 +3243,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-096.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-096.json",
@@ -3254,7 +3254,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-097.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-097.json",
@@ -3265,7 +3265,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-098.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-098.json",
@@ -3276,7 +3276,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-099.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-099.json",
@@ -3287,7 +3287,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-100.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-100.json",
@@ -3298,7 +3298,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_B-140.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_B-140.json",
@@ -3309,7 +3309,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Ba-001.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ba-001.json",
@@ -3320,7 +3320,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Ba-002.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ba-002.json",
@@ -3331,7 +3331,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Ba-003.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Ba-003.json",
@@ -3342,7 +3342,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-004.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-004.json",
@@ -3353,7 +3353,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-005.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-005.json",
@@ -3364,7 +3364,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-006.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-006.json",
@@ -3375,7 +3375,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-007.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-007.json",
@@ -3386,7 +3386,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-008.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-008.json",
@@ -3397,7 +3397,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-009.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-009.json",
@@ -3408,7 +3408,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-010.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-010.json",
@@ -3419,7 +3419,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-011.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-011.json",
@@ -3430,7 +3430,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-012.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-012.json",
@@ -3441,7 +3441,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-013.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-013.json",
@@ -3452,7 +3452,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-014.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-014.json",
@@ -3463,7 +3463,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-015.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-015.json",
@@ -3474,7 +3474,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-016.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-016.json",
@@ -3485,7 +3485,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-017.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-017.json",
@@ -3496,7 +3496,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-018.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-018.json",
@@ -3507,7 +3507,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-019.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-019.json",
@@ -3518,7 +3518,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-020.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-020.json",
@@ -3529,7 +3529,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-021.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-021.json",
@@ -3540,7 +3540,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-022.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-022.json",
@@ -3551,7 +3551,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-023.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-023.json",
@@ -3562,7 +3562,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-024.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-024.json",
@@ -3573,7 +3573,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-025.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-025.json",
@@ -3584,7 +3584,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-026.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-026.json",
@@ -3595,7 +3595,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-027.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-027.json",
@@ -3606,7 +3606,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-028.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-028.json",
@@ -3617,7 +3617,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-029.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-029.json",
@@ -3628,7 +3628,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-030.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-030.json",
@@ -3639,7 +3639,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-031.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-031.json",
@@ -3650,7 +3650,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-032.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-032.json",
@@ -3661,7 +3661,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-033.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-033.json",
@@ -3672,7 +3672,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-034.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-034.json",
@@ -3683,7 +3683,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-035.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-035.json",
@@ -3694,7 +3694,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-036.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-036.json",
@@ -3705,7 +3705,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-037.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-037.json",
@@ -3716,7 +3716,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-038.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-038.json",
@@ -3727,7 +3727,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-039.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-039.json",
@@ -3738,7 +3738,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-040.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-040.json",
@@ -3749,7 +3749,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-041.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-041.json",
@@ -3760,7 +3760,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-042.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-042.json",
@@ -3771,7 +3771,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-043.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-043.json",
@@ -3782,7 +3782,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-044.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-044.json",
@@ -3793,7 +3793,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-045.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-045.json",
@@ -3804,7 +3804,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-046.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-046.json",
@@ -3815,7 +3815,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-047.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-047.json",
@@ -3826,7 +3826,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-048.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-048.json",
@@ -3837,7 +3837,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-049.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-049.json",
@@ -3848,7 +3848,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-050.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-050.json",
@@ -3859,7 +3859,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-051.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-051.json",
@@ -3870,7 +3870,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-052.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-052.json",
@@ -3881,7 +3881,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-053.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-053.json",
@@ -3892,7 +3892,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-054.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-054.json",
@@ -3903,7 +3903,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-055.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-055.json",
@@ -3914,7 +3914,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-056.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-056.json",
@@ -3925,7 +3925,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-057.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-057.json",
@@ -3936,7 +3936,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-058.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-058.json",
@@ -3947,7 +3947,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-059.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-059.json",
@@ -3958,7 +3958,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-060.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-060.json",
@@ -3969,7 +3969,7 @@
         {
             "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ],
             "filepath": "srd13_Br-061.json",
             "downloadURL": "http://www.nist.gov/srd/srd_data/srd13_Br-061.json",

--- a/model/nerdm-bib-schema.json
+++ b/model/nerdm-bib-schema.json
@@ -1,0 +1,134 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$extensionSchemas": ["https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
+    "id": "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.4#",
+    "rev": "wd1",
+    "title": "The NERDm extension metadata for bibliographic information",
+    "description": "This schema extends NERDm's BibliographicReference to provide more specific ways to describe scholory references.",
+    "definitions": {
+
+        "DCiteRefType": {
+            "description": "a bibliographical reference type with a defined set of values that are drawn from the DataCite Metadata Schema's relationType",
+            "notes": [
+                "The values are defined to be identical to (or more specific than) the corresponding terms in the DataCite Metadata Schema",
+                "The subset of defined here are those that are considered most applicable to data resources provided by the NIST Public Data Repository (PDR) and for which the PDR may recognize and provide special handling for."
+            ],
+            "type": "string",
+            "enum": [ "IsDocumentedBy", "IsSupplementTo", "IsSupplementedBy",
+                      "IsCitedBy", "Cites", "IsReviewedBy",
+                      "IsReferencedBy", "References",
+                      "IsSourceOf", "IsDerivedFrom",
+                      "IsNewVersionOf", "IsPreviousVersionOf" ],
+            "valueDocumentation": {
+                "IsDocumentedBy": {
+                    "description": "The referenced document provides documentation of this resource.",
+                    "notes": [
+                        "This type should be applied to the reference that provides the best, most complete, or otherwise most preferred description of how the data in this resource was created.",
+                        "This resource is expected to be or include a human-readable document."
+                    ]
+                },
+                "IsSupplementTo": {
+                    "description": "The referenced document is a supplement to this resource.",
+                    "notes": [
+                        "A supplement typically refers to data that is closely associated with a journal article that serves as the primary description of how the data was taken and what results were extracted from them.",
+                        "This resource is expected to be or include a human-readable document.",
+                        "The resource is usually considered the primary reference for this data resource"
+                    ]
+                },
+                "IsSupplementedBy": {
+                    "description": "The referenced document (or dataset) is a supplement to this resource.",
+                    "notes": [
+                        "This can be applied to refer to other datasets that may have resulted from the same experimental/observational activity but which might be considered less central of useful to other, e.g. calibration data."
+                    ]
+                },
+                "IsCitedBy": {
+                    "description": "The referenced document cites the resource in some way.",
+                    "notes": [
+                        "This relationship indicates is lighter than IsReferenceBy: the referenced document may discuss this resource without drawing on and using data or information from this resource."
+                    ]
+                },
+                "Cites": {
+                    "description": "This resource cites the referenced document.",
+                    "notes": [
+                        "Human readable descriptions can refer to this type of resource via its label, e.g. '...previous research [Smith98; Jones10]...'",
+                        "Like IsCitedBy, the relationship indicated is lighter than References: this resource makes reference to the referenced resource in discussion without necessarily drawing on and using data or information from that resource."
+                    ]
+                },
+                "IsReviewedBy": {
+                    "description": "The referenced document reviews this resource.",
+                    "notes": [
+                        "This is a lighter relationship than the resource property, describedBy; the latter refers to a document that is the primary, detailed description and/or analysis of this resource"
+                    ]
+                },
+                "IsReferencedBy": {
+                    "description": "The resource is used as a source of information by the referenced document.",
+                    "notes": [
+                    ]
+                },
+                "References": {
+                    "description": "The referenced document is used as a source of information by the resource.",
+                    "notes": [
+                        "This type is provided as a general purpose reference to documents or data that are indirectly relate to this one",
+                        "This type is recommend for references provided for citations in the textual description (e.g. the description property) of this resource."
+                    ]
+                },
+                "IsSourceOf": {
+                    "description": "The resource is the source of upon which the referenced resource is based.",
+                    "notes": [
+                        "In other words, the referenced document is derived from the resource.",
+                        "This is a stronger relationship than 'References'"
+                    ]
+                },
+                "IsDerivedFrom": {
+                    "description": "The referenced document is the source upon which the resource is based.",
+                    "notes": [
+                        "In other words, the resource is derived from the referenced document.",
+                        "This is a stronger relationship than 'IsReferencedBy'"
+                    ]
+                },
+                "IsNewVersionOf": {
+                    "description": "The referenced resource is a previous version of this resource.",
+                    "notes": [
+                        "This usually means that the referenced resource is deprecated by this one."
+                    ]
+                },
+                "IsPreviousVersionOf": {
+                    "description": "The referenced resource is a newer version of this resource.",
+                    "notes": [
+                        "This usually means that the referenced resource deprecates this one."
+                    ]
+                },
+                "IsVariantOf": {
+                    "description": "The referenced resource contains the content of this resource in a different form.",
+                    "notes": [
+                        "As an example, the referenced resource may be based on the same raw data but calibrated differently."
+                    ]
+                }
+            }
+        },
+
+        "DCiteReference": {
+            "description": "a bibliographical reference with a controlled vocabulary for its reference type (refType)",
+            "notes": [
+                "Note that some refType values are specifically for references of type npg:Document:  'isDocumentedBy', 'isReviewedBy'; 'isSupplementTo' typically labels a reference of type npg:Document",
+                "Use 'isSupplementTo' or 'isDocumentedBy' to indicate documents that provide the most comprehensive explanation of the contents of the resource.  'isSupplementTo' is preferred when the document presents results drawn from the data.  List these documents in order of importance (as the first one will be exported as the 'describedBy' document when converted to the POD schema).",
+                "It is recommended that such multiple classifications of the same reference should be avoided."
+            ],
+            "allOf": [
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/BibliographicReference" },
+                {
+                    "properties": {
+                        "refType": {
+                            "description": "a term indicating the nature of the relationship between this resource and the one being referenced",
+                            "notes": [
+                                "Note that with this term, the subject of relationship is the resource described by this NERDm record and the object is the referenced resource given by the @id property in this node.  Although this violates the JSON-LD semantics that properties in this node should describe what's given with the local @id--the referenced resource, in this case--it is more consistant with their use in the DataCite schema."
+                            ],
+                            "$ref": "#/definitions/DCiteRefType"
+                        }
+                    },
+                    "required": [ "refType" ]
+                }
+            ]
+        }
+    }
+}

--- a/model/nerdm-pub-schema.json
+++ b/model/nerdm-pub-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "$extensionSchemas": ["https://data.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
-    "id": "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#",
+    "id": "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#",
     "rev": "wd1",
     "title": "The NERDm extension metadata for Public Data",
     "description": "These classes extend the based NERDm schema to different types of published data",
@@ -13,7 +13,7 @@
                 "This must be convertable to a compliant and complete POD record; thus, this class adds all remaining POD elements missing from the core"
             ],
             "allOf": [
-                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/Resource"},
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/Resource"},
                 {
                     "type": "object",
                     "properties": {
@@ -184,7 +184,7 @@
         "DownloadableFile": {
             "description": "a description of a downloadable, finite stream of data",
             "allOf": [
-                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/Component" },
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/Component" },
                 {
                     "properties": {
 
@@ -331,7 +331,7 @@
                     "properties": {
                         "algorithm": {
                             "description": "the algorithm used to produce the checksum hash",
-                            "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/Topic"
+                            "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/Topic"
                         },
                         
                         "valid": {
@@ -359,7 +359,7 @@
             "properties": {
                 "algorithm": {
                     "description": "the algorithm used to produce the checksum hash",
-                    "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/Topic"
+                    "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/Topic"
                 },
                 "hash": {
                     "description": "the checksum value",
@@ -380,7 +380,7 @@
                 "This Component subtype implements hierarchical resources; a subcollection is equivalent to a directory that can contain other components, including other subcollections."
             ],
             "allOf": [
-                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/Component" },
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/Component" },
                 {
                     "properties": {
                         
@@ -433,7 +433,7 @@
                 "This type should not be used to capture a resource's home page as this would be redundant with the landingPage resource property."
             ],
             "allOf": [
-                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/Component" },
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/Component" },
                 {
                     "properties": {
                         "accessURL": {
@@ -475,7 +475,7 @@
                 "When converting an API component to a POD distribution, the output format should set to 'API'."
             ],
             "allOf": [
-                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/Component" },
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/Component" },
                 {
                     "properties": {
                         "accessURL": {
@@ -729,7 +729,7 @@
         "Affiliation": {
             "description":  "a description of an organization that a person is a member of",
             "allOf": [
-                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/ResourceReference" },
+                { "$ref": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/ResourceReference" },
                 {
                     "properties": {
                         "subunits": { 

--- a/model/nerdm-schema.json
+++ b/model/nerdm-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "$extensionSchemas": ["https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#"],
-    "id": "https://data.nist.gov/od/dm/nerdm-schema/v0.3#",
+    "id": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#",
     "rev": "wd1",
     "title": "The JSON Schema for the NIST Extended Resource Data model (NERDm)",
     "description": "A JSON Schema specfying the core NERDm classes",
@@ -651,7 +651,7 @@
                                 "Note that with this term, the subject of relationship is the resource described by this NERDm record and the object is the referenced resource given by the @id property in this node.  Although this violates the JSON-LD semantics that properties in this node should describe what's given with the local @id--the referenced resource, in this case--it is more consistant with their use in the DataCite schema."
                             ],
                             "type": "string",
-                            "enum": [ "IsDocumentedBy", "IsSupplementedTo",
+                            "enum": [ "IsDocumentedBy", "IsSupplementTo", "IsSupplementedBy",
                                       "IsCitedBy", "Cites", "IsReviewedBy",
                                       "IsReferencedBy", "References",
                                       "IsSourceOf", "IsDerivedFrom",
@@ -664,10 +664,18 @@
                                         "This resource is expected to be or include a human-readable document."
                                     ]
                                 },
-                                "IsSupplementedTo": {
+                                "IsSupplementTo": {
                                     "description": "The referenced document is a supplement to this resource.",
                                     "notes": [
-                                        "a supplement typically refers to data (often small) that appears closely attached to a journal article."
+                                        "A supplement typically refers to data that is closely associated with a journal article that serves as the primary description of how the data was taken and what results were extracted from them.",
+                                        "This resource is expected to be or include a human-readable document.",
+                                        "The resource is usually considered the primary reference for this data resource"
+                                    ]
+                                },
+                                "IsSupplementedBy": {
+                                    "description": "The referenced document (or dataset) is a supplement to this resource.",
+                                    "notes": [
+                                        "This can be applied to refer to other datasets that may have resulted from the same experimental/observational activity but which might be considered less central of useful to other, e.g. calibration data."
                                     ]
                                 },
                                 "IsCitedBy": {
@@ -697,6 +705,8 @@
                                 "References": {
                                     "description": "The referenced document is used as a source of information by the resource.",
                                     "notes": [
+                                        "This type is provided as a general purpose reference to documents or data that are indirectly relate to this one",
+                                        "This type is recommend for references provided for citations in the textual description (e.g. the description property) of this resource."
                                     ]
                                 },
                                 "IsSourceOf": {

--- a/model/nerdm-schema.json
+++ b/model/nerdm-schema.json
@@ -419,7 +419,8 @@
                 "abbrev": {
                     "description": "an abbreviated form of the resource's title",
                     "notes": [
-                        "this can be used as a label for a compact display or text for a link to this resource"
+                        "this can be used as a label for a compact display or text for a link to this resource",
+                        "this may be helpful for discovery when an abbreviation is included in a free-text search"
                     ],
                     "type": "array",
                     "items": {
@@ -623,128 +624,12 @@
                             "description": "the type of relationship that this document has with the resource",
                             "notes": [
                                 "This is equivalent to the Datacite relationType in that the term is a predicate that connects the resource as the subject to the referenced document as the object (e.g. resource IsDocumentedBy referenced-doc)",
-                                "The DCiteReference type sets DataCite terms as controlled vocabulary"
+                                "The DCiteReference type from Bibliographic extension sets DataCite terms as controlled vocabulary"
                             ],
                             "type": "string"
                         }
                     },
                     "required": [ "@type", "location" ]
-                }
-            ]
-        },
-
-        "DCiteReference": {
-            "description": "a bibliographical reference with a controlled vocabulary for its reference type (refType)",
-            "notes": [
-                "Note that some refType values are specifically for references of type npg:Document:  'isDocumentedBy', 'isReviewedBy'",
-                "Use 'isDocumentedBy' to indicate documents that provide the most comprehensive explanation of the contents of the resource.  List these documents in order of importance (as the first one will be exported as the 'describedBy' document when converted to the POD schema).",
-                "Use 'isSourceOf' if the document provides analysis and interpretation of the resource.  In particular, journal articles that are co-published with this resource should be listed with this type.  It is recommended that these documents be listed either in order of publication date or importance.",
-                "Documents may be listed more than once having different types, namely both 'isDocumentedBy' and 'isSourceOf'; however, it is recommended that such multiple classifications should be minimized."
-            ],
-            "allOf": [
-                { "$ref": "#/definitions/BibliographicReference" },
-                {
-                    "properties": {
-                        "refType": {
-                            "description": "a term indicating the nature of the relationship between this resource and the one being referenced",
-                            "notes": [
-                                "Note that with this term, the subject of relationship is the resource described by this NERDm record and the object is the referenced resource given by the @id property in this node.  Although this violates the JSON-LD semantics that properties in this node should describe what's given with the local @id--the referenced resource, in this case--it is more consistant with their use in the DataCite schema."
-                            ],
-                            "type": "string",
-                            "enum": [ "IsDocumentedBy", "IsSupplementTo", "IsSupplementedBy",
-                                      "IsCitedBy", "Cites", "IsReviewedBy",
-                                      "IsReferencedBy", "References",
-                                      "IsSourceOf", "IsDerivedFrom",
-                                      "IsNewVersionOf", "IsPreviousVersionOf" ],
-                            "valueDocumentation": {
-                                "IsDocumentedBy": {
-                                    "description": "The referenced document provides documentation of this resource.",
-                                    "notes": [
-                                        "This type should be applied to the reference that provides the best, most complete, or otherwise most preferred description of how the data in this resource was created.",
-                                        "This resource is expected to be or include a human-readable document."
-                                    ]
-                                },
-                                "IsSupplementTo": {
-                                    "description": "The referenced document is a supplement to this resource.",
-                                    "notes": [
-                                        "A supplement typically refers to data that is closely associated with a journal article that serves as the primary description of how the data was taken and what results were extracted from them.",
-                                        "This resource is expected to be or include a human-readable document.",
-                                        "The resource is usually considered the primary reference for this data resource"
-                                    ]
-                                },
-                                "IsSupplementedBy": {
-                                    "description": "The referenced document (or dataset) is a supplement to this resource.",
-                                    "notes": [
-                                        "This can be applied to refer to other datasets that may have resulted from the same experimental/observational activity but which might be considered less central of useful to other, e.g. calibration data."
-                                    ]
-                                },
-                                "IsCitedBy": {
-                                    "description": "The referenced document cites the resource in some way.",
-                                    "notes": [
-                                        "This relationship indicates is lighter than IsReferenceBy: the referenced document may discuss this resource without drawing on and using data or information from this resource."
-                                    ]
-                                },
-                                "Cites": {
-                                    "description": "This resource cites the referenced document.",
-                                    "notes": [
-                                        "Human readable descriptions can refer to this type of resource via its label, e.g. '...previous research [Smith98; Jones10]...'",
-                                        "Like IsCitedBy, the relationship indicated is lighter than References: this resource makes reference to the referenced resource in discussion without necessarily drawing on and using data or information from that resource."
-                                    ]
-                                },
-                                "IsReviewedBy": {
-                                    "description": "The referenced document reviews this resource.",
-                                    "notes": [
-                                        "This is a lighter relationship than the resource property, describedBy; the latter refers to a document that is the primary, detailed description and/or analysis of this resource"
-                                    ]
-                                },
-                                "IsReferencedBy": {
-                                    "description": "The resource is used as a source of information by the referenced document.",
-                                    "notes": [
-                                    ]
-                                },
-                                "References": {
-                                    "description": "The referenced document is used as a source of information by the resource.",
-                                    "notes": [
-                                        "This type is provided as a general purpose reference to documents or data that are indirectly relate to this one",
-                                        "This type is recommend for references provided for citations in the textual description (e.g. the description property) of this resource."
-                                    ]
-                                },
-                                "IsSourceOf": {
-                                    "description": "The resource is the source of upon which the referenced resource is based.",
-                                    "notes": [
-                                        "In other words, the referenced document is derived from the resource.",
-                                        "This is a stronger relationship than 'References'"
-                                    ]
-                                },
-                                "IsDerivedFrom": {
-                                    "description": "The referenced document is the source upon which the resource is based.",
-                                    "notes": [
-                                        "In other words, the resource is derived from the referenced document.",
-                                        "This is a stronger relationship than 'IsReferencedBy'"
-                                    ]
-                                },
-                                "IsNewVersionOf": {
-                                    "description": "The referenced resource is a previous version of this resource.",
-                                    "notes": [
-                                        "This usually means that the referenced resource is deprecated by this one."
-                                    ]
-                                },
-                                "IsPreviousVersionOf": {
-                                    "description": "The referenced resource is a newer version of this resource.",
-                                    "notes": [
-                                        "This usually means that the referenced resource deprecates this one."
-                                    ]
-                                },
-                                "IsVariantOf": {
-                                    "description": "The referenced resource contains the content of this resource in a different form.",
-                                    "notes": [
-                                        "As an example, the referenced resource may be based on the same raw data but calibrated differently."
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "required": [ "refType" ]
                 }
             ]
         },

--- a/model/tests/test_bib.py
+++ b/model/tests/test_bib.py
@@ -50,6 +50,20 @@ class TestExamples(test.TestCase):
         schema = nerdmbib + "/definitions/DCiteReference"
         self.val.validate(tstref, False, True, schema, True)
 
+    def test_attype(self):
+        tstref = {
+            u'refType': u'IsDocumentedBy',
+            u'location': u'http://kinetics.nist.gov/janaf/pdf/JANAF-FourthEd-1998-1Vol1-Intro.pdf',
+            u'_extensionSchemas': [
+                u'https://data.nist.gov/od/dm/nerdm-schema/bib/v0.4#/definitions/DCiteReference'
+            ],
+            u'@type': [u'schema:Book'],
+            u'label': u'JPCRD Monograph: NIST-JANAF Thermochemical Tables, Pt. 1 (AL-C'
+        }
+
+        schema = nerdm + "/definitions/BibliographicReference"
+        self.val.validate(tstref, False, True, schema, True)
+
 
         
         

--- a/model/tests/test_bib.py
+++ b/model/tests/test_bib.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+#
+import os, json, pdb
+import unittest as test
+import ejsonschema as ejs
+
+from jsonschema.exceptions import ValidationError
+
+nerdm = "https://data.nist.gov/od/dm/nerdm-schema/v0.4#"
+nerdmbib = "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.4#"
+
+schemadir = os.path.dirname(os.path.dirname(__file__))
+exdir = os.path.join(schemadir, "examples")
+jqlib = os.path.join(os.path.dirname(schemadir), "jq")
+datadir = os.path.join(jqlib, "tests", "data")
+pdlfile = os.path.join(datadir, "nist-pdl-oct2016.json")
+
+class TestExamples(test.TestCase):
+
+    def setUp(self):
+        loader = ejs.SchemaLoader.from_directory(schemadir)
+        self.val = ejs.ExtValidator(loader, ejsprefix='_')
+
+    def validate_file(self, filename):
+        fpath = os.path.join(exdir, filename)
+        with open(fpath) as fd:
+            data = json.load(fd)
+
+        self.val.validate(data, False, True)
+
+    def test_refType(self):
+        schema = nerdmbib + "/definitions/DCiteRefType"
+        self.val.validate("References", False, True, schema, True)
+        self.val.validate("IsReferencedBy", False, True, schema, True)
+        self.val.validate("IsSupplementTo", False, True, schema, True)
+        self.val.validate("IsDocumentedBy", False, True, schema, True)
+        self.val.validate("IsCitedBy", False, True, schema, True)
+        self.val.validate("Cites", False, True, schema, True)
+        with self.assertRaises(ValidationError):
+            self.val.validate("IsSupplementedTo", False, True, schema, True)
+        
+    def test_DCiteReference(self):
+        tstref = {
+            "@id": "https://doi.org/10.88434/goober",
+            "@type": ["dcat:Dataset"],
+            "location": "https://data.nist.gov/goober",
+            "refType": "References"
+        }
+
+        schema = nerdmbib + "/definitions/DCiteReference"
+        self.val.validate(tstref, False, True, schema, True)
+
+
+        
+        
+
+if __name__ == '__main__':
+    test.main()
+

--- a/python/nistoar/doi/resolving/__init__.py
+++ b/python/nistoar/doi/resolving/__init__.py
@@ -49,10 +49,14 @@ class Resolver(object):
         doi = _comm.strip_DOI(doi, self._resolver)
         url = self._resolver + doi
 
+        hdrs = {"Accept": CT.Citeproc_JSON}
+        ua = get_default_user_agent()
+        if ua:
+            hdrs['User-Agent'] = ua
+
         # Do a HEAD request on the DOI to examine where it gets forwarded to
         try:
-            resp = requests.head(url, headers={"Accept": CT.Citeproc_JSON},
-                                 allow_redirects=False)
+            resp = requests.head(url, headers=hdrs, allow_redirects=False)
         except (requests.ConnectionError,
                 requests.HTTPError,
                 requests.ConnectTimeout)   as ex:
@@ -80,10 +84,11 @@ class Resolver(object):
             info = DOIInfo(doi, resolver=self._resolver, logger=self._log)
 
         elif _cc_resolver_re.match(loc):
-            info = CrossciteDOIInfo(doi, resolver=self._resolver,
-                                    logger=self._log)
+            info = CrossciteDOIInfo(doi, resolver=self._resolver, logger=self._log,
+                                    client_info=self._client_info)
         elif _dc_resolver_re.match(loc):
-            info = DataciteDOIInfo(doi, resolver=self._resolver,logger=self._log)
+            info = DataciteDOIInfo(doi, resolver=self._resolver,logger=self._log,
+                                   client_info=self._client_info)
         elif _cr_resolver_re.match(loc):
             info = CrossrefDOIInfo(doi, resolver=self._resolver,logger=self._log,
                                    client_info=self._client_info)

--- a/python/nistoar/doi/resolving/crosscite.py
+++ b/python/nistoar/doi/resolving/crosscite.py
@@ -7,8 +7,8 @@ class CrossciteDOIInfo(DOIInfo):
     """
 
     def __init__(self, doi, source="Crosscite", resolver=default_doi_resolver,
-                 logger=None):
-        super(CrossciteDOIInfo, self).__init__(doi, source, resolver, logger)
+                 logger=None, client_info=None):
+        super(CrossciteDOIInfo, self).__init__(doi, source, resolver, logger, client_info)
 
     @property
     def native(self):

--- a/python/nistoar/doi/resolving/crossref.py
+++ b/python/nistoar/doi/resolving/crossref.py
@@ -12,13 +12,9 @@ class CrossrefDOIInfo(DOIInfo):
 
     def __init__(self, doi, source="Crossref", resolver=default_doi_resolver,
                  logger=None, client_info=None):
-        super(CrossrefDOIInfo, self).__init__(doi, source, resolver, logger)
-
-        self.client_info = None
-        if not client_info:
-            client_info = _comm._client_info
-        if client_info:
-            self.client_info = xref.Etiquette(*client_info)
+        super(CrossrefDOIInfo, self).__init__(doi, source, resolver, logger, client_info)
+        if self._client_info:
+            self._client_info = xref.Etiquette(*self._client_info)
 
     @property
     def native(self):

--- a/python/nistoar/doi/resolving/datacite.py
+++ b/python/nistoar/doi/resolving/datacite.py
@@ -7,8 +7,8 @@ class DataciteDOIInfo(DOIInfo):
     """
 
     def __init__(self, doi, source="Datacite", resolver=default_doi_resolver,
-                 logger=None):
-        super(DataciteDOIInfo, self).__init__(doi, source, resolver, logger)
+                 logger=None, client_info=None):
+        super(DataciteDOIInfo, self).__init__(doi, source, resolver, logger, client_info)
 
     @property
     def native(self):

--- a/python/nistoar/doi/resolving/tests/test_crossref.py
+++ b/python/nistoar/doi/resolving/tests/test_crossref.py
@@ -1,7 +1,7 @@
 import os, sys, pdb, shutil, logging, json
 import unittest as test
 from collections import Mapping
-from nistoar.tests import *
+# from nistoar.tests import *
 
 import nistoar.doi.resolving.crossref as res
 from nistoar.doi.resolving.common import set_client_info
@@ -40,6 +40,17 @@ class TestCrossrefDOIInfo(test.TestCase):
         self.assertIsNotNone(doi.client_info)
         self.assertEqual(doi.client_info.application_version, "testing")
 
+    def test_get_default_headers(self):
+        set_client_info(None, None, None, None)
+        doi = res.CrossrefDOIInfo(crdoi)
+        hdrs = doi.get_default_headers()
+        self.assertEqual(hdrs, {})
+
+        doi = res.CrossrefDOIInfo(crdoi, client_info=("test", "v0", "url", "email"))
+        self.assertTrue(doi.user_agent.startswith("test/v0 (url; mailto:email) BasedOn: CrossrefAPI/"))
+        hdrs = doi.get_default_headers()
+        self.assertEqual(hdrs, {"User-Agent": doi.user_agent})
+        
 
     @test.skipIf("doi" not in os.environ.get("OAR_TEST_INCLUDE",""),
                  "kindly skipping doi service checks")

--- a/python/nistoar/doi/resolving/tests/test_datacite.py
+++ b/python/nistoar/doi/resolving/tests/test_datacite.py
@@ -1,7 +1,7 @@
 import os, sys, pdb, shutil, logging, json
 import unittest as test
 from collections import Mapping
-from nistoar.tests import *
+# from nistoar.tests import *
 
 import nistoar.doi.resolving.datacite as res
 
@@ -25,7 +25,7 @@ class TestDataciteDOIInfo(test.TestCase):
         self.assertTrue(isinstance(doi.native, Mapping))
         self.assertTrue(isinstance(doi._native, Mapping))
         self.assertIn('url', doi.native)
-        self.assertEqual(doi.native['doi'], dcdoi)
+        self.assertEqual(doi.native['doi'].lower(), dcdoi)
         
         
         

--- a/python/nistoar/doi/resolving/tests/test_resolving.py
+++ b/python/nistoar/doi/resolving/tests/test_resolving.py
@@ -1,7 +1,7 @@
 import os, sys, pdb, shutil, logging, json
 import unittest as test
 from collections import Mapping
-from nistoar.tests import *
+# from nistoar.tests import *
 
 import nistoar.doi.resolving as res
 import nistoar.doi.resolving.common as comm
@@ -24,7 +24,7 @@ class TestResolving(test.TestCase):
                  "kindly skipping doi service checks")
     def test_resolve_dc(self):
         info = res.resolve(dcdoi, logger=logger)
-        self.assertEqual(info.source, "Datacite")
+        self.assertIn(info.source, ["Datacite", "Crosscite"])
         self.assertTrue(isinstance(info, res.DataciteDOIInfo))
         self.assertIsNotNone(info._data)
         self.assertEqual(info.data['DOI'], dcdoi)

--- a/python/nistoar/nerdm/constants.py
+++ b/python/nistoar/nerdm/constants.py
@@ -20,6 +20,13 @@ def pub_schema_uri_for(version):
     """
     return schema_uri_for(core_schema_base+"pub/", version)
 
+def bib_schema_uri_for(version):
+    """
+    return the schema URI for the requested version of the Core NERDm schema
+    @raises ValueError   if the given version is not a recognized version
+    """
+    return schema_uri_for(core_schema_base+"bib/", version)
+
 def schema_uri_for(schema_base, version):
     """
     return the schema URI for the requested version of the Core NERDm schema
@@ -35,6 +42,7 @@ def schema_uri_for(schema_base, version):
 
 CORE_SCHEMA_URI = core_schema_uri_for(schema_versions[0])
 PUB_SCHEMA_URI = pub_schema_uri_for(schema_versions[0])
+BIB_SCHEMA_URI = bib_schema_uri_for(schema_versions[0])
 
 TAXONOMY_VOCAB_BASE_URI = "https://data.nist.gov/od/dm/nist-themes/"
 TAXONOMY_VOCAB_INIT_URI = "https://www.nist.gov/od/dm/nist-themes/v1.0"

--- a/python/nistoar/nerdm/constants.py
+++ b/python/nistoar/nerdm/constants.py
@@ -4,7 +4,7 @@ data to make them available from Python.
 """
 core_schema_base = "https://data.nist.gov/od/dm/nerdm-schema/"
 
-schema_versions = ["v0.3", "v0.2", "v0.1"]
+schema_versions = ["v0.4", "v0.3", "v0.2", "v0.1"]
 
 def core_schema_uri_for(version):
     """

--- a/python/nistoar/nerdm/convert/pod.py
+++ b/python/nistoar/nerdm/convert/pod.py
@@ -560,7 +560,7 @@ def _doiinfo2reference(info, resolver):
         out['refType'] = "References"
     elif tp.startswith('article'):
         out['@type'] = ['schema:Article']
-        out['refType'] = "IsCitedBy"
+        out['refType'] = "IsSupplementedBy"
     elif tp == 'book':
         out['@type'] = ['schema:Book']
         out['refType'] = "References"

--- a/python/nistoar/nerdm/convert/pod.py
+++ b/python/nistoar/nerdm/convert/pod.py
@@ -7,7 +7,7 @@ from collections import OrderedDict, Mapping
 from ... import jq
 from ...doi import resolve, is_DOI
 from ...doi.resolving import Resolver
-from ..constants import (CORE_SCHEMA_URI, PUB_SCHEMA_URI,
+from ..constants import (CORE_SCHEMA_URI, PUB_SCHEMA_URI, BIB_SCHEMA_URI,
                          TAXONOMY_VOCAB_BASE_URI, TAXONOMY_VOCAB_URI)
 from ..taxonomy import ResearchTopicsTaxonomy
 
@@ -587,7 +587,7 @@ def _doiinfo2reference(info, resolver):
     if info.citation_text:
         out['citation'] = info.citation_text
 
-    out['_extensionSchemas'] = [ CORE_SCHEMA_URI+"#/definitions/DCiteReference" ]
+    out['_extensionSchemas'] = [ BIB_SCHEMA_URI+"#/definitions/DCiteReference" ]
     return out
 
     

--- a/python/nistoar/nerdm/convert/pod.py
+++ b/python/nistoar/nerdm/convert/pod.py
@@ -560,7 +560,7 @@ def _doiinfo2reference(info, resolver):
         out['refType'] = "References"
     elif tp.startswith('article'):
         out['@type'] = ['schema:Article']
-        out['refType'] = "IsSupplementedBy"
+        out['refType'] = "IsCitedBy"
     elif tp == 'book':
         out['@type'] = ['schema:Book']
         out['refType'] = "References"

--- a/python/nistoar/nerdm/convert/tests/test_pod_doi.py
+++ b/python/nistoar/nerdm/convert/tests/test_pod_doi.py
@@ -240,7 +240,7 @@ class TestConvertReferences(unittest.TestCase):
         ref = cvt._doiinfo2reference(info, "https://goober.org/")
         self.assertEqual(ref['@type'], ['schema:Article'])
         self.assertEqual(ref['@id'], 'doi:10.10/XXX')
-        self.assertEqual(ref['refType'], 'IsCitedBy')
+        self.assertEqual(ref['refType'], 'IsSupplementedBy')
         self.assertEqual(ref['title'],
                          "Ecological traits of the world\u2019s primates")
         self.assertEqual(ref['location'], "https://goober.org/10.10/XXX")

--- a/python/nistoar/nerdm/convert/tests/test_pod_doi.py
+++ b/python/nistoar/nerdm/convert/tests/test_pod_doi.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 
 import nistoar.nerdm.convert.pod as cvt
 from nistoar.doi.resolving import DOIInfo
-from nistoar.nerdm.constants import CORE_SCHEMA_URI, PUB_SCHEMA_URI
+from nistoar.nerdm.constants import CORE_SCHEMA_URI, PUB_SCHEMA_URI, BIB_SCHEMA_URI
 
 citeproc_auths = [
     {u'affiliation': [], u'given': u'Carmen', u'family':
@@ -263,7 +263,7 @@ class TestConvertReferences(unittest.TestCase):
         self.assertEqual(ref['citation'], 'ibid')
         self.assertIn('_extensionSchemas', ref)
         self.assertTrue(isinstance(ref['_extensionSchemas'], list))
-        self.assertTrue(ref['_extensionSchemas'][0].startswith(CORE_SCHEMA_URI + "#/definitions/"),
+        self.assertTrue(ref['_extensionSchemas'][0].startswith(BIB_SCHEMA_URI + "#/definitions/"),
                         msg="Unexpected extension schema URI: "+ref['_extensionSchemas'][0])
 
 class TestDOIResolver(unittest.TestCase):

--- a/python/nistoar/nerdm/convert/tests/test_pod_doi.py
+++ b/python/nistoar/nerdm/convert/tests/test_pod_doi.py
@@ -240,7 +240,7 @@ class TestConvertReferences(unittest.TestCase):
         ref = cvt._doiinfo2reference(info, "https://goober.org/")
         self.assertEqual(ref['@type'], ['schema:Article'])
         self.assertEqual(ref['@id'], 'doi:10.10/XXX')
-        self.assertEqual(ref['refType'], 'IsSupplementedBy')
+        self.assertEqual(ref['refType'], 'IsCitedBy')
         self.assertEqual(ref['title'],
                          "Ecological traits of the world\u2019s primates")
         self.assertEqual(ref['location'], "https://goober.org/10.10/XXX")

--- a/python/nistoar/nerdm/convert/tests/test_pod_doi.py
+++ b/python/nistoar/nerdm/convert/tests/test_pod_doi.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 
 import nistoar.nerdm.convert.pod as cvt
 from nistoar.doi.resolving import DOIInfo
+from nistoar.nerdm.constants import CORE_SCHEMA_URI, PUB_SCHEMA_URI
 
 citeproc_auths = [
     {u'affiliation': [], u'given': u'Carmen', u'family':
@@ -262,7 +263,8 @@ class TestConvertReferences(unittest.TestCase):
         self.assertEqual(ref['citation'], 'ibid')
         self.assertIn('_extensionSchemas', ref)
         self.assertTrue(isinstance(ref['_extensionSchemas'], list))
-        self.assertTrue(ref['_extensionSchemas'][0].startswith("https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/"), msg="Unexpected extension schema URI: "+ref['_extensionSchemas'][0])
+        self.assertTrue(ref['_extensionSchemas'][0].startswith(CORE_SCHEMA_URI + "#/definitions/"),
+                        msg="Unexpected extension schema URI: "+ref['_extensionSchemas'][0])
 
 class TestDOIResolver(unittest.TestCase):
 

--- a/python/nistoar/rmm/mongo/nerdm.py
+++ b/python/nistoar/rmm/mongo/nerdm.py
@@ -7,7 +7,7 @@ from .loader import (Loader, RecordIngestError, JSONEncodingError,
                      UpdateWarning, LoadLog)
 from .loader import ValidationError, SchemaError, RefResolutionError
 
-DEF_BASE_SCHEMA = "https://data.nist.gov/od/dm/nerdm-schema/v0.1#"
+DEF_BASE_SCHEMA = "https://data.nist.gov/od/dm/nerdm-schema/v0.4#"
 DEF_SCHEMA = DEF_BASE_SCHEMA + "/definitions/Resource"
 
 COLLECTION_NAME="record"


### PR DESCRIPTION
This PR is one part of the solution addressing [ODD-926, "Data Supplemental Paper Reference"](http://mml.nist.gov:8080/browse/ODD-929) (especially sub-task [ODD-938](http://mml.nist.gov:8080/browse/ODD-938)).  This implements the convention to mark the paper reference most associated with a NERDm data resource as having `refType` of `IsSupplementTo` and to assume reference URLs entered via MIDAS will be of this type.  This PR also fixes a typo in the NERDm schema definition for this type (which previously was named "IsSupplementedTo").  Finally, as a stabilization for further evolution of the reference type terms, the DataCite reference type term definitions were moved to a new extension schema, `nerdm-bib-schema.json`.  

See [oar-pdr PR#165](https://github.com/usnistgov/oar-pdr/pull/165) for details on testing this PR in concert with its related PRs in support of [ODD-926](http://mml.nist.gov:8080/browse/ODD-929). 