### PR TITLE
Add support for github actions as replacement for travis-ci

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: testall
+name: integration
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,25 @@
+name: testall
+on:
+  workflow_dispatch:
+  push:
+    branches: ['integration']
+jobs:
+  testall:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Containers
+        env:
+          OAR_DOCKERHUB_CRED: ${{ secrets.OAR_DOCKERHUB_CRED }}
+        run: |
+          bash scripts/dhsetup.sh
+          cd docker && bash ./dockbuild.sh
+
+      - name: Run Unit Tests via Docker
+        run: cd docker && ./testall
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: testall
+name: main
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: testall
+on:
+  workflow_dispatch:
+  push:
+    branches: ['main']
+jobs:
+  testall:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Containers
+        env:
+          OAR_DOCKERHUB_CRED: ${{ secrets.OAR_DOCKERHUB_CRED }}
+        run: |
+          bash scripts/dhsetup.sh
+          cd docker && bash ./dockbuild.sh
+
+      - name: Run Unit Tests via Docker
+        run: cd docker && ./testall
+

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -1,0 +1,28 @@
+name: testall
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches-ignore: ['main', 'integration']
+    paths:
+      - 'python/**'
+jobs:
+  testall:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Containers
+        env:
+          OAR_DOCKERHUB_CRED: ${{ secrets.OAR_DOCKERHUB_CRED }}
+        run: |
+          bash scripts/dhsetup.sh
+          cd docker && bash ./dockbuild.sh
+
+      - name: Run Unit Tests via Docker
+        run: cd docker && ./testall
+

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -1,7 +1,6 @@
-name: testall
+name: source updates
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches-ignore: ['main', 'integration']
     paths:

--- a/.github/workflows/testall.yml
+++ b/.github/workflows/testall.yml
@@ -1,0 +1,29 @@
+name: testall
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches-ignore: ['main', 'integration']
+    paths:
+      - 'docker/**'
+      - '.github/workflows/**'
+jobs:
+  testall:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Containers
+        env:
+          OAR_DOCKERHUB_CRED: ${{ secrets.OAR_DOCKERHUB_CRED }}
+        run: |
+          bash scripts/dhsetup.sh
+          cd docker && bash ./dockbuild.sh
+
+      - name: Run Unit Tests via Docker
+        run: cd docker && ./testall
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Metadata Support for the OAR Open Data Platform (via NERDm)
 
+[![main branch status](https://github.com/usnistgov/oar-rmm/actions/workflows/main.yml/badge.svg)](https://github.com/usnistgov/oar-rmm/actions/workflows/main.yml) | 
+[![integration branch status](https://github.com/usnistgov/oar-rmm/actions/workflows/integration.yml/badge.svg)](https://github.com/usnistgov/oar-rmm/actions/workflows/integration.yml)
+
 This package provides support for metadata across the different
 components of the OAR Open Data Platform.  At the core of this support
 is the NERD model; this package includes its JSON Schema and Linked


### PR DESCRIPTION
Travis-CI has been used as our continuous integration service that automatically runs unit tests with every push and pull request to the repository.  With Travis-CI's reduction of free limits, we are migrating our CI scripts to GitHub Actions.  This PR introduces those scripts (held in `.github/workflows`).  GitHub Actions provides greater flexibility for configuring triggered workflows, so several scripts are introduced following the patter established in [oar-rmm](https://github.com/usnistgov/oar-rmm) (see [PR#36](https://github.com/usnistgov/oar-rmm/pull/36)).  

To test, ensure that the GitHub action check-marks appear in this PR page. Click on the mark to access the log for the action.