### PR TITLE
Improve reporting of error messages during DOI registration

### DIFF
--- a/docker/dockbuild.sh
+++ b/docker/dockbuild.sh
@@ -34,6 +34,6 @@ setup_build
 log_intro   # record start of build into log
 
 for container in $BUILD_IMAGES; do 
-    echo '+ ' docker build $BUILD_OPTS -t $PACKAGE_NAME/$container $container | logit
-    docker build $BUILD_OPTS -t $PACKAGE_NAME/$container $container 2>&1 | logit
+    echo '+ ' docker build $BUILD_OPTS -t $PACKAGE_NAME/${container}-py2 $container | logit
+    docker build $BUILD_OPTS -t $PACKAGE_NAME/${container}-py2 $container 2>&1 | logit
 done

--- a/docker/ejsonschema/Dockerfile
+++ b/docker/ejsonschema/Dockerfile
@@ -1,4 +1,4 @@
-FROM oar-metadata/jqfromsrc:latest
+FROM oar-metadata/jqfromsrc-py2:latest
 
 RUN apt-get update && apt-get install -y python python-pip python-dev unzip \
                                          uwsgi uwsgi-plugin-python python-yaml

--- a/docker/jqfromsrc/Dockerfile
+++ b/docker/jqfromsrc/Dockerfile
@@ -1,4 +1,4 @@
-From oar-metadata/pymongo
+From oar-metadata/pymongo-py2
 
 RUN apt-get update && \
     apt-get install -y libonig-dev curl build-essential libtool zip \

--- a/docker/mdtests/Dockerfile
+++ b/docker/mdtests/Dockerfile
@@ -1,4 +1,4 @@
-FROM oar-metadata/ejsonschema
+FROM oar-metadata/ejsonschema-py2
 
 RUN apt-get update && apt-get install -y zip wget git
 COPY verify-asc.sh /usr/local/bin

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -56,5 +56,5 @@ while [ "$1" != "" ]; do
 done
 
 
-echo '+' docker run $ti --rm -v $codedir:/dev/oar-metadata $distvol oar-metadata/mdtests $cmd "${args[@]}"
-exec docker run $ti --rm -v $codedir:/dev/oar-metadata $distvol oar-metadata/mdtests $cmd "${args[@]}"
+echo '+' docker run $ti --rm -v $codedir:/dev/oar-metadata $distvol oar-metadata/mdtests-py2 $cmd "${args[@]}"
+exec docker run $ti --rm -v $codedir:/dev/oar-metadata $distvol oar-metadata/mdtests-py2 $cmd "${args[@]}"

--- a/python/nistoar/doi/datacite.py
+++ b/python/nistoar/doi/datacite.py
@@ -354,6 +354,9 @@ class JSONAPIError(object):
                 self.edata = [ { "title": "Unknown error" } ]
 
     def message(self):
+        if self.defmsg:
+            return self.defmsg
+
         out = self._format_error(self.edata[0])
         if len(self.edata) > 1:
             out += " (plus other errors)"

--- a/python/nistoar/doi/resolving/common.py
+++ b/python/nistoar/doi/resolving/common.py
@@ -300,7 +300,7 @@ class DOIClientException(DOIResolutionException):
     """
     An exception during DOI resolution traceable to client input
     """
-    def __init__(self, doi, resolver=None, message=None, errdata=None):
+    def __init__(self, doi, resolver=None, message=None, errdata=None, cause=None):
         """
         initialize the exception
 
@@ -316,7 +316,7 @@ class DOIClientException(DOIResolutionException):
         """
         if not message:
             message = "Unknown client error during DOI resolution of " + doi
-        super(DOIClientException, self).__init__(message, doi, resolver, errdata)
+        super(DOIClientException, self).__init__(message, doi, resolver, cause, errdata)
 
 
 class DOIDoesNotExist(DOIClientException):


### PR DESCRIPTION
Communication with the remote DOI service fails on occasion (e.g. due to network issues).  On such occasions, the error message in the log was not forth-coming as to why.  This PR provides more detailed info about the failure.  

This PR is intended for the python2-based 1.0.X line.  It also provides some tweaks to the docker containers: image names have been modified so as not to be confused with the python3 versions of the main line. 