### PR TITLE
NERDm schema: Adapt datacite conversion for change to isPartOf

### DIFF
--- a/jq/nerdm2datacite.jq
+++ b/jq/nerdm2datacite.jq
@@ -336,20 +336,25 @@ def make_ispartof_rel:
       {
         relatedIdentifier: .["@id"] | todoiurl,
         relatedIdentifierType: "DOI",
-        relationType: "isPartOf"
+        relationType: "IsPartOf"
       }
-    elif (.location) then
-      {
-        relatedIdentifier: (.location | todoiurl),
-        relationType: "isPartOf"
-      } |
-      if (.relatedIdentifier | test("^https?://(dx.)?doi.org/")) then
-          (.relatedIdentifierType = "DOI")
-      else
-          (.relatedIdentifierType = "URL")
-      end
     else
-      empty
+      if ((.location|not) and .["@id"] and (.["@id"] | contains("ark:/88434/"))) then
+        .location = "https://data.nist.gov/od/id/" + .["@id"]
+      end |
+      if (.location) then
+        {
+          relatedIdentifier: (.location | todoiurl),
+          relationType: "IsPartOf"
+        } |
+        if (.relatedIdentifier | test("^https?://(dx.)?doi.org/")) then
+            (.relatedIdentifierType = "DOI")
+        else
+            (.relatedIdentifierType = "URL")
+        end
+      else
+        empty
+      end
     end
 ;
 
@@ -442,7 +447,7 @@ def resource2datacite:
       ],
       relatedIdentifiers: [
         (
-          (.isPartOf | make_ispartof_rel),
+          (.isPartOf | if (.) then (.[] | make_ispartof_rel) else empty end),
           (.references | if (.) then (.[] | make_ref_rel) else empty end),
           (.isReplacedBy | make_obsoletedby_rel)
         )

--- a/jq/tests/test_nerdm2datacite.jqt
+++ b/jq/tests/test_nerdm2datacite.jqt
@@ -300,34 +300,41 @@ include "nerdm2datacite"; make_formats
 #
 include "nerdm2datacite"; make_ispartof_rel
 { "@id": "doi:10.18434/spd0fjpek351", "location": "http://dx.doi.org/10.18434/spd0fjpek351", "title": "Hello!"}
-{ "relatedIdentifier": "https://doi.org/10.18434/spd0fjpek351", "relatedIdentifierType": "DOI", "relationType": "isPartOf" }
+{ "relatedIdentifier": "https://doi.org/10.18434/spd0fjpek351", "relatedIdentifierType": "DOI", "relationType": "IsPartOf" }
 
 #--------------
 # testing make_ispartof_rel
 #
 include "nerdm2datacite"; make_ispartof_rel
 { "@id": "http://doi.org/10.18434/spd0fjpek351", "location": "http://dx.doi.org/10.18434/spd0fjpek351", "title": "Hello!"}
-{ "relatedIdentifier": "https://doi.org/10.18434/spd0fjpek351", "relatedIdentifierType": "DOI", "relationType": "isPartOf" }
+{ "relatedIdentifier": "https://doi.org/10.18434/spd0fjpek351", "relatedIdentifierType": "DOI", "relationType": "IsPartOf" }
 
 #--------------
 # testing make_ispartof_rel
 #
 include "nerdm2datacite"; make_ispartof_rel
 { "location": "http://dx.doi.org/10.18434/spd0fjpek351", "title": "Hello!"}
-{ "relatedIdentifier": "https://doi.org/10.18434/spd0fjpek351", "relatedIdentifierType": "DOI", "relationType": "isPartOf" }
+{ "relatedIdentifier": "https://doi.org/10.18434/spd0fjpek351", "relatedIdentifierType": "DOI", "relationType": "IsPartOf" }
 
 #--------------
 # testing make_ispartof_rel
 #
 include "nerdm2datacite"; make_ispartof_rel
 { "@id": "ark:/88434/jres0-1", "location": "http://jres.nist.gov/10.18434/spd0fjpek351", "title": "Hello!"}
-{ "relatedIdentifier": "http://jres.nist.gov/10.18434/spd0fjpek351", "relatedIdentifierType": "URL", "relationType": "isPartOf" }
+{ "relatedIdentifier": "http://jres.nist.gov/10.18434/spd0fjpek351", "relatedIdentifierType": "URL", "relationType": "IsPartOf" }
 
 #--------------
-# testing make_ispartof_rel:  should return an empty result
+# testing make_ispartof_rel:  should a PDR URL
 #
 include "nerdm2datacite"; make_ispartof_rel
 { "@id": "ark:/88434/jres0-1", "title": "Hello!"}
+{ "relatedIdentifier": "https://data.nist.gov/od/id/ark:/88434/jres0-1", "relatedIdentifierType": "URL", "relationType": "IsPartOf" }
+
+#--------------
+# testing make_ispartof_rel:  should return an empty result (because the ID is unrecognized)
+#
+include "nerdm2datacite"; make_ispartof_rel
+{ "@id": "ark:/88888/jres0-1", "title": "Hello!"}
 
 # Line above must be empty
 


### PR DESCRIPTION
With v0.6 of the core NERDm schema, the "isPartOf" property was changed to be an array of references (rather than just a single reference).  At that time, the supporting code was updated; however, the NERDm-to-DataCite jq conversion script was not.  This PR fixes the conversion (including a bug setting the output `relationType`).  

This fix is being applied to the 1.0.X line.  A separate PR will apply the fix to the main-integration line