### PR TITLE
Move version handling functions from oar-pdr into new nistoar.id.versions module

### DIFF
--- a/docker/ejsonschema/Dockerfile
+++ b/docker/ejsonschema/Dockerfile
@@ -9,7 +9,7 @@ RUN PYTHON=python3.8 uwsgi --build-plugin "/usr/src/uwsgi/plugins/python python3
 RUN update-alternatives --install /usr/lib/uwsgi/plugins/python3_plugin.so \
     python_plugin.so /usr/lib/uwsgi/plugins/python38_plugin.so 1
 
-RUN python -m pip install setuptools --upgrade
+RUN python -m pip install "setuptools<66.0.0"
 RUN python -m pip install json-spec jsonschema==2.4.0 requests \
                           pytest==4.6.5 filelock crossrefapi pyyaml
 RUN python -m pip install --no-dependencies jsonmerge==1.3.0 

--- a/python/nistoar/id/versions.py
+++ b/python/nistoar/id/versions.py
@@ -153,7 +153,7 @@ class OARVersion(Version):
     def __str__(self):
         return self._vs + self._sfx
 
-    def increment_field(self, pos: int):
+    def increment_field(self, pos: int) -> OARVersion:
         """
         increment the field of the version at a given position.  If this version has a suffix
         indicative of a draft (see :py:meth:`is_draft`), the suffix will be dropped. 
@@ -161,6 +161,8 @@ class OARVersion(Version):
                          change field positions relative to the end (i.e. -1 increments the last field).
                          If the ``pos`` indicates a position beyond the current number of fields, the 
                          version fields will be padded with zeros up to that position before incrementing.
+        :returns:  self, allowing for chaining with, say, :py:meth:`drop_suffix`.
+                   :rtype: OARVersion
         :raises IndexError: if th
         """
         if pos >= len(self.fields):
@@ -176,32 +178,43 @@ class OARVersion(Version):
         if self.is_draft():
             self.drop_suffix()
 
+        return self
+
     def trivial_incr(self):
         """
         increment the third field of the version representing a metadata or other trivial change
         in the document it is assinged to.
+        :returns:  self, allowing for chaining with, say, :py:meth:`drop_suffix`.
+                   :rtype: OARVersion
         """
-        increment_level(2)
+        return increment_level(2)
         
     def minor_incr(self):
         """
         increment the third field of the version representing a data or other minor change
         in the document it is assinged to.
+        :returns:  self, allowing for chaining with, say, :py:meth:`drop_suffix`.
+                   :rtype: OARVersion
         """
-        self.increment_field(1)
+        return self.increment_field(1)
 
     def major_incr(self):
         """
         increment the third field of the version representing a major change
         in the document it is assinged to.
+        :returns:  self, allowing for chaining with, say, :py:meth:`drop_suffix`.
+                   :rtype: OARVersion
         """
-        self.increment_field(0)
+        return self.increment_field(0)
 
     def drop_suffix(self):
         """
         remove the suffix from this version
+        :returns:  self, allowing for chaining with, say, :py:meth:`incrment_field`.
+                   :rtype: OARVersion
         """
         self._sfx = ''
+        return self
 
 def cmp_oar_versions(ver1: str, ver2: str) -> int:
     """

--- a/python/nistoar/id/versions.py
+++ b/python/nistoar/id/versions.py
@@ -6,7 +6,7 @@ used by the OAR framework.
 The centerpiece of this module is the :py:class:`Version` class which allow a version string to be 
 compared for sorting or to be incremented.  
 """
-import re
+import re, typing
 
 __all__ = [ "Version", "OARVersion", "cmp_versions", "cmp_oar_versions" ]
 
@@ -77,6 +77,8 @@ def cmp_versions(ver1: str, ver2: str) -> int:
     elif a == b:
         return 0
     return +1
+
+OARVersion = typing.NewType("OARVersion", Version)
 
 class OARVersion(Version):
     """
@@ -180,7 +182,7 @@ class OARVersion(Version):
 
         return self
 
-    def trivial_incr(self):
+    def trivial_incr(self) -> OARVersion:
         """
         increment the third field of the version representing a metadata or other trivial change
         in the document it is assinged to.
@@ -189,7 +191,7 @@ class OARVersion(Version):
         """
         return increment_level(2)
         
-    def minor_incr(self):
+    def minor_incr(self) -> OARVersion:
         """
         increment the third field of the version representing a data or other minor change
         in the document it is assinged to.
@@ -198,7 +200,7 @@ class OARVersion(Version):
         """
         return self.increment_field(1)
 
-    def major_incr(self):
+    def major_incr(self) -> OARVersion:
         """
         increment the third field of the version representing a major change
         in the document it is assinged to.
@@ -207,7 +209,7 @@ class OARVersion(Version):
         """
         return self.increment_field(0)
 
-    def drop_suffix(self):
+    def drop_suffix(self) -> OARVersion:
         """
         remove the suffix from this version
         :returns:  self, allowing for chaining with, say, :py:meth:`incrment_field`.

--- a/python/nistoar/id/versions.py
+++ b/python/nistoar/id/versions.py
@@ -1,0 +1,219 @@
+"""
+Utilities for managing semantic version strings that will be assigned to OAR documents 
+when they are released (e.g. published).  This module implements the version convention 
+used by the OAR framework.  
+
+The centerpiece of this module is the :py:class:`Version` class which allow a version string to be 
+compared for sorting or to be incremented.  
+"""
+import re
+
+__all__ = [ "Version", "OARVersion", "cmp_versions", "cmp_oar_versions" ]
+
+_ver_delim = re.compile(r"[\._]")
+_numeric_ver = re.compile(r"^\d+([\._]\d+)*")
+_proper_ver = re.compile(_numeric_ver.pattern+'$')
+
+class Version(object):
+    """
+    a version class that can facilitate comparisons
+    """
+
+    def _toint(self, field):
+        try:
+            return int(field)
+        except ValueError:
+            return field
+
+    def __init__(self, vers):
+        """
+        convert a version string to a Version instance
+        """
+        self._vs = vers
+        self.fields = [self._toint(n) for n in _ver_delim.split(self._vs)]
+
+    def __str__(self):
+        return self._vs
+
+    def __eq__(self, other):
+        if not isinstance(other, Version):
+            other = Version(other)
+        return self.fields == other.fields
+
+    def __lt__(self, other):
+        if not isinstance(other, Version):
+            other = Version(other)
+        return self.fields < other.fields
+
+    def __le__(self, other):
+        if not isinstance(other, Version):
+            other = Version(other)
+        return self < other or self == other
+
+    def __ge__(self, other):
+        return not (self < other)
+    def __gt__(self, other):
+        return not self.__le__(other)
+    def __ne__(self, other):
+        return not (self == other)
+
+    @classmethod
+    def is_proper_version(cls, vers: str) -> bool:
+        """
+        return true if the given version string is of the form M.M.M... where
+        each M is any non-negative number.   
+        """
+        return _proper_ver.match(vers) is not None
+
+def cmp_versions(ver1: str, ver2: str) -> int:
+    """
+    compare two version strings for their order.
+    :return int:  -1 if v1 < v2, 0 if v1 = v2, and +1 if v1 > v2
+    """
+    a = Version(ver1)
+    b = Version(ver2)
+    if a < b:
+        return -1
+    elif a == b:
+        return 0
+    return +1
+
+class OARVersion(Version):
+    """
+    a Version class that supports OAR document version label conventions.
+
+    The OAR document version conventions are:
+      * contains at least 3 numeric fields
+      * an increment in the third field (from the left) represents a
+        change in only the document's metadata or similar inconsequential
+        change.
+      * an increment in the second field represents a consequential change
+        which may include a change in the attached data products.
+      * an increment in the first field represenets a major shift in the 
+        scope or aim of the document.  Such an increment is usually a choice 
+        of the document's authors (as it implies intent) as opposed to 
+        some automatically applied based on specific technical criteria.
+      * a version whose last field is followed by a '+' (and additional 
+        optional characters) indicate that the document is in draft form 
+        and whose version to be applied at publication time has not yet been 
+        set.  The version to the left of the '+' is the version of the 
+        previously published version that the draft is derived from.  
+
+    This class provides support for the above conventions for incrementing the version.  
+    If simple comparison is all that is needed, then the lighterweight :py:class:`Version`
+    should be used instead.  
+    """
+
+    def __init__(self, vers):
+        self._sfx = ''
+        m = _numeric_ver.match(vers)
+        if m:
+            self._sfx = vers[m.end():]
+            vers = vers[:m.end()]
+        super(OARVersion, self).__init__(vers)
+
+    @property
+    def suffix(self):
+        return self._sfx
+
+    def is_draft(self):
+        """
+        return True if this version represents 
+        """
+        return False if not self._sfx else self._sfx[0] == '+'
+
+    def __eq__(self, other):
+        if not isinstance(other, OARVersion):
+            other = OARVersion(str(other))
+
+        if self.suffix != other.suffix:
+            return False
+        return super().__eq__(other)
+
+    def __lt__(self, other):
+        if not isinstance(other, OARVersion):
+            other = OARVersion(str(other))
+
+        if self.fields == other.fields:
+            if other.suffix and self.is_draft() and not other.is_draft():
+                return True
+            elif self.suffix and not self.is_draft() and other.is_draft():
+                return False
+            return self.suffix < other.suffix
+
+        return self.fields < other.fields
+
+    def _set(self, *flds, suffix=''):
+        vers = '.'.join([str(f) for f in flds]) + suffix
+        new = OARVersion(vers)
+        self._vs = new._vs
+        self.fields = new.fields
+        self._sfx = new.suffix
+
+    def __str__(self):
+        return self._vs + self._sfx
+
+    def increment_field(self, pos: int):
+        """
+        increment the field of the version at a given position.  If this version has a suffix
+        indicative of a draft (see :py:meth:`is_draft`), the suffix will be dropped. 
+        :param int pos:  the 0-origin position of the field to increment.  The value can be negative to
+                         change field positions relative to the end (i.e. -1 increments the last field).
+                         If the ``pos`` indicates a position beyond the current number of fields, the 
+                         version fields will be padded with zeros up to that position before incrementing.
+        :raises IndexError: if th
+        """
+        if pos >= len(self.fields):
+            for i in range(len(self.fields), pos+1):
+                self.fields.append(0)
+        elif pos < -1*len(self.fields):
+            raise IndexError(pos)
+
+        self.fields[pos] += 1
+        for i in range(pos+1, len(self.fields)):
+            self.field[i] = 0
+        self._vs = '.'.join([str(f) for f in self.fields])
+        if self.is_draft():
+            self.drop_suffix()
+
+    def trivial_incr(self):
+        """
+        increment the third field of the version representing a metadata or other trivial change
+        in the document it is assinged to.
+        """
+        increment_level(2)
+        
+    def minor_incr(self):
+        """
+        increment the third field of the version representing a data or other minor change
+        in the document it is assinged to.
+        """
+        self.increment_field(1)
+
+    def major_incr(self):
+        """
+        increment the third field of the version representing a major change
+        in the document it is assinged to.
+        """
+        self.increment_field(0)
+
+    def drop_suffix(self):
+        """
+        remove the suffix from this version
+        """
+        self._sfx = ''
+
+def cmp_oar_versions(ver1: str, ver2: str) -> int:
+    """
+    compare two version strings for their order using the OAR document version conventions
+    :return int:  -1 if v1 < v2, 0 if v1 = v2, and +1 if v1 > v2
+    """
+    a = OARVersion(ver1)
+    b = OARVersion(ver2)
+    if a < b:
+        return -1
+    elif a == b:
+        return 0
+    return +1
+
+    

--- a/python/tests/nistoar/id/test_versions.py
+++ b/python/tests/nistoar/id/test_versions.py
@@ -1,0 +1,172 @@
+import os, sys, pdb, shutil, logging, json
+import unittest as test
+
+import nistoar.id.versions as util
+
+class TestVersion(test.TestCase):
+
+    def test_ctor(self):
+        ver = util.Version("3.3.5.0")
+        self.assertEqual(ver._vs, "3.3.5.0")
+        self.assertEqual(ver.fields, [3,3,5,0])
+
+    def testEQ(self):
+        ver = util.Version("3.3.0")
+        self.assertEqual(ver, util.Version("3.3.0"))
+        self.assertTrue(ver == "3.3.0")
+        self.assertFalse(ver == "3.3.1")
+        self.assertFalse(ver == "1.3")
+
+    def testNE(self):
+        ver = util.Version("3.3.0")
+        self.assertNotEqual(ver, util.Version("3.3.2"))
+        self.assertFalse(ver != "3.3.0")
+        self.assertTrue(ver != "3.3.1")
+        self.assertTrue(ver != "1.3")
+
+    def testGE(self):
+        ver = util.Version("3.3.0")
+        self.assertTrue(ver >= "3.2.0")
+        self.assertTrue(ver >= "3.3.0")
+        self.assertTrue(ver >= "1.3")
+
+        self.assertFalse(ver >= "5.3")
+        self.assertFalse(ver >= util.Version("5.3"))
+
+    def testGT(self):
+        ver = util.Version("3.3.0")
+        self.assertTrue(ver > "3.2.0")
+        self.assertTrue(ver > "1.3")
+
+        self.assertFalse(ver > "3.3.0")
+        self.assertFalse(ver >= "5.3")
+        self.assertFalse(ver >= util.Version("5.3"))
+
+    def testLE(self):
+        ver = util.Version("3.3.0")
+        self.assertTrue(ver <= "3.5.0")
+        self.assertTrue(ver <= "3.3.1")
+        self.assertTrue(ver <= "3.3.0")
+        self.assertTrue(ver <= "5.3")
+
+        self.assertFalse(ver <= "1.3")
+        self.assertFalse(ver <= util.Version("2.3"))
+
+    def testLT(self):
+        ver = util.Version("3.3.0")
+        self.assertTrue(ver < "3.5.0")
+        self.assertTrue(ver < "3.3.1")
+        self.assertTrue(ver < "5.3")
+
+        self.assertFalse(ver < "3.3.0")
+        self.assertFalse(ver < "1.3")
+        self.assertFalse(ver < util.Version("2.3"))
+
+    def testIsProper(self):
+        self.assertTrue(util.Version.is_proper_version("33"))
+        self.assertTrue(util.Version.is_proper_version("3.3"))
+        self.assertTrue(util.Version.is_proper_version("13_3_0"))
+        self.assertTrue(util.Version.is_proper_version("1.23_400.10"))
+
+        self.assertFalse(util.Version.is_proper_version("-33"))
+        self.assertFalse(util.Version.is_proper_version("3.3r23"))
+        self.assertFalse(util.Version.is_proper_version("13.3.0-1"))
+        self.assertFalse(util.Version.is_proper_version("dev"))
+
+    def test_sorted(self):
+        vers = "2.0.1 3.0 0.1.1 0 12.3 2.0.1.0".split()
+        expect = "0 0.1.1 2.0.1 2.0.1.0 3.0 12.3".split()
+        self.assertEqual(sorted(vers, key=util.Version), expect)
+
+    def test_cmp_versions(self):
+        self.assertEqual(util.cmp_versions("1.0.0", "1.0.2"), -1)
+        self.assertEqual(util.cmp_versions("1.0.1", "1.0.1"),  0)
+        self.assertEqual(util.cmp_versions("1.0.2", "1.0.1"),  1)
+        self.assertEqual(util.cmp_versions("1.0", "1.0.2"), -1)
+        self.assertEqual(util.cmp_versions("1.0.0", "1.0"),  1)
+        self.assertEqual(util.cmp_versions("1", "1.0"),  -1)
+        self.assertEqual(util.cmp_versions("1.0.2", "1.1.0"), -1)
+        self.assertEqual(util.cmp_versions("1.2.1", "1.0.1"),  1)
+        self.assertEqual(util.cmp_versions("1.0.2", "4.0.1"), -1)
+        self.assertEqual(util.cmp_versions("12.0.2", "4.0.1"), 1)
+    
+class TestOARVersion(test.TestCase):
+
+    def test_ctor(self):
+        ver = util.OARVersion("3.3.5.0")
+        self.assertEqual(ver._vs, "3.3.5.0")
+        self.assertEqual(ver.fields, [3,3,5,0])
+        self.assertEqual(ver.suffix, '')
+
+        ver = util.OARVersion("3.3.5.0.1goob30")
+        self.assertEqual(ver._vs, "3.3.5.0.1")
+        self.assertEqual(ver.fields, [3,3,5,0,1])
+        self.assertEqual(ver.suffix, 'goob30')
+
+        ver = util.OARVersion("3.3+what")
+        self.assertEqual(ver._vs, "3.3")
+        self.assertEqual(ver.fields, [3,3])
+        self.assertEqual(ver.suffix, '+what')
+
+    def testEQ(self):
+        ver = util.OARVersion("3.3.0rc1")
+        self.assertEqual(ver, util.Version("3.3.0rc1"))
+        self.assertTrue(ver == "3.3.0rc1")
+        self.assertFalse(ver == "3.3.0")
+        self.assertFalse(ver == "3.3.1")
+        self.assertFalse(ver == "1.3")
+
+        ver = util.OARVersion("3.3.0")
+        self.assertEqual(ver, util.Version("3.3.0"))
+        self.assertTrue(ver == "3.3.0")
+        self.assertFalse(ver == "3.3.1")
+        self.assertFalse(ver == "1.3")
+
+    def testLT(self):
+        ver = util.OARVersion("3.3.0")
+        self.assertTrue(ver < "3.5.0")
+        self.assertTrue(ver < "3.3.1")
+        self.assertTrue(ver < "3.3.1+")
+        self.assertTrue(ver < "5.3")
+
+        self.assertFalse(ver < "3.3.0")
+        self.assertFalse(ver < "1.3")
+        self.assertFalse(ver < util.Version("2.3"))
+
+        ver = util.OARVersion("3.3.0+ (in edit)")
+        self.assertFalse(ver < "3.3.0")
+        self.assertTrue(ver < "3.3.0#rc1")
+        self.assertTrue(ver < "3.3.0rc1")
+        
+        self.assertFalse(ver < "3.3.0+")
+        self.assertFalse(ver < "3.3.0+ (in Edit)")
+
+        ver = util.OARVersion("3.3.0rc3")
+        self.assertFalse(ver < "3.3.0alpha3")
+        
+
+    def test_cmp_oar_versions(self):
+        self.assertEqual(util.cmp_oar_versions("1.0.0", "1.0.2"), -1)
+        self.assertEqual(util.cmp_oar_versions("1.0.1", "1.0.1"),  0)
+        self.assertEqual(util.cmp_oar_versions("1.0.2", "1.0.1"),  1)
+        self.assertEqual(util.cmp_oar_versions("1.0", "1.0.2"), -1)
+        self.assertEqual(util.cmp_oar_versions("1.0.0", "1.0"),  1)
+        self.assertEqual(util.cmp_oar_versions("1", "1.0"),  -1)
+        self.assertEqual(util.cmp_oar_versions("1.0.2", "1.1.0"), -1)
+        self.assertEqual(util.cmp_oar_versions("1.2.1", "1.0.1"),  1)
+        self.assertEqual(util.cmp_oar_versions("1.0.2", "4.0.1"), -1)
+        self.assertEqual(util.cmp_oar_versions("12.0.2", "4.0.1"), 1)
+    
+        self.assertEqual(util.cmp_oar_versions("1.0.1", "1.0.1+draft"), -1)
+        self.assertEqual(util.cmp_oar_versions("1.0.1+", "1.0.1"),  1)
+        self.assertEqual(util.cmp_oar_versions("1.0.1+", "1.0.1+"), 0)
+        self.assertEqual(util.cmp_oar_versions("1.0.12alpha", "1.0.12beta"), -1)
+        self.assertEqual(util.cmp_oar_versions("1.0.12beta", "1.0.12alpha"),  1)
+        self.assertEqual(util.cmp_oar_versions("1.0.12beta", "1.0.12beta"),   0)
+        self.assertEqual(util.cmp_oar_versions("1.0.1beta", "1.0.12beta"),   -1)
+        self.assertEqual(util.cmp_oar_versions("1.0.12+", "1.0.12beta"),     -1)
+
+                    
+                         
+if __name__ == '__main__':
+    test.main()

--- a/scripts/_install-env.sh
+++ b/scripts/_install-env.sh
@@ -41,10 +41,10 @@ while [ "$1" != "" ]; do
 done
 
 [ "$INSTALL_DIR" = "/usr/local" ] && {
-    true ${PY_LIBDIR:=$INSTALL_DIR/lib/python2.7/dist-packages}
+    true ${PY_LIBDIR:=$INSTALL_DIR/lib/python3.8/dist-packages}
 }
 [ "$INSTALL_DIR" = "/usr" ] && {
-    true ${PY_LIBDIR:=$INSTALL_DIR/lib/python2.7}
+    true ${PY_LIBDIR:=$INSTALL_DIR/lib/python3.8}
 }
 
 true ${ETC_DIR:=$INSTALL_DIR/etc}


### PR DESCRIPTION
This PR pulls some version setting and comparing functions that used to be part of `bagger.utils` into its own module, `nistoar.id.versions`, and expands it with additional capabilities.  This allows it to be used more broadly by different systems.  This PR also includes some fixes that further rids dependencies on/artifacts of python 2.7.