### PR TITLE
1.0.X: Fix jq modules and fix unit tests after uprev to nerdm 0.7

### DIFF
--- a/.github/workflows/testall.yml
+++ b/.github/workflows/testall.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'docker/**'
       - '.github/workflows/**'
+      - 'jq/**'
 jobs:
   testall:
     runs-on: ubuntu-20.04

--- a/jq/pod2nerdm.jq
+++ b/jq/pod2nerdm.jq
@@ -21,15 +21,15 @@ include "urldecode";
 
 # the base NERDm JSON schema namespace
 #
-def nerdm_schema:  "https://data.nist.gov/od/dm/nerdm-schema/v0.6#";
+def nerdm_schema:  "https://data.nist.gov/od/dm/nerdm-schema/v0.7#";
 
 # the NERDm pub schema extension namespace
 #
-def nerdm_pub_schema:  "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.6#";
+def nerdm_pub_schema:  "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#";
 
 # the NERDm bib schema extension namespace
 #
-def nerdm_bib_schema:  "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.6#";
+def nerdm_bib_schema:  "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.7#";
 
 # the NERDm context location
 #

--- a/jq/tests/test_pod2nerdm.jqt
+++ b/jq/tests/test_pod2nerdm.jqt
@@ -10,14 +10,14 @@
 #
 include "pod2nerdm"; nerdm_schema
 null
-"https://data.nist.gov/od/dm/nerdm-schema/v0.6#"
+"https://data.nist.gov/od/dm/nerdm-schema/v0.7#"
 
 #--------------
 # testing nerdm_schema()
 #
 include "pod2nerdm"; nerdm_pub_schema
 null
-"https://data.nist.gov/od/dm/nerdm-schema/pub/v0.6#"
+"https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#"
 
 #--------------
 # testing nerdm_context()
@@ -31,7 +31,7 @@ null
 #
 include "pod2nerdm"; dciteRefType
 null
-"https://data.nist.gov/od/dm/nerdm-schema/bib/v0.6#/definitions/DCiteReference"
+"https://data.nist.gov/od/dm/nerdm-schema/bib/v0.7#/definitions/DCiteReference"
 
 #--------------
 # testing resid()
@@ -91,7 +91,7 @@ include "pod2nerdm"; pdrLandingPageURL
 #
 include "pod2nerdm"; map(cvtref)
 [ "http://goob.net/doc1.txt", "https://goob.gov/doc2.txt" ]
-[{ "@type": ["deo:BibliographicReference"],"@id":"#ref:doc1.txt", "refType": "IsSupplementTo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.6#/definitions/DCiteReference" ], "location": "http://goob.net/doc1.txt"}, { "@type": ["deo:BibliographicReference"],"@id":"#ref:doc2.txt", "refType": "IsSupplementTo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.6#/definitions/DCiteReference" ], "location": "https://goob.gov/doc2.txt"}]
+[{ "@type": ["deo:BibliographicReference"],"@id":"#ref:doc1.txt", "refType": "IsSupplementTo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.7#/definitions/DCiteReference" ], "location": "http://goob.net/doc1.txt"}, { "@type": ["deo:BibliographicReference"],"@id":"#ref:doc2.txt", "refType": "IsSupplementTo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.7#/definitions/DCiteReference" ], "location": "https://goob.gov/doc2.txt"}]
 
 #---------------
 # testing filepath()
@@ -220,14 +220,14 @@ include "pod2nerdm"; map(componentID("#"))
 #
 include "pod2nerdm"; dist2download
 {"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json", "mediaType": "application/json","title": "Titanium Boride" }
-{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.6#/definitions/DataFile"]}
+{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"]}
 
 #--------------
 # testing dist2checksum()
 #
 include "pod2nerdm"; dist2checksum
 {"downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json.sha256", "title": "Checksum for srd13_B-101.json" }
-{"downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json.sha256","mediaType": "text/plain", "description": "SHA-256 checksum value for srd13_B-101.json", "title": "Checksum for srd13_B-101.json", "filepath":"srd13_B-101.json.sha256", "algorithm": {"@type": "Thing","tag": "sha256"},"@type": ["nrdp:ChecksumFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json.sha256","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.6#/definitions/ChecksumFile"]}
+{"downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json.sha256","mediaType": "text/plain", "description": "SHA-256 checksum value for srd13_B-101.json", "title": "Checksum for srd13_B-101.json", "filepath":"srd13_B-101.json.sha256", "algorithm": {"@type": "Thing","tag": "sha256"},"@type": ["nrdp:ChecksumFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json.sha256","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"]}
 
 #--------------
 # testing dist2hidden()
@@ -248,7 +248,7 @@ include "pod2nerdm"; dist2inaccess
 #
 include "pod2nerdm"; dist2accesspage
 {"accessURL": "https://doi.org/10.18434/T42C7D","title": "A Library to Enable the Modeling of Optical Imaging of Finite Multi-Line Arrays"}
-{"accessURL": "https://doi.org/10.18434/T42C7D","title": "A Library to Enable the Modeling of Optical Imaging of Finite Multi-Line Arrays","@type": [ "nrdp:AccessPage", "dcat:Distribution" ],"@id":"#10.18434/T42C7D","_extensionSchemas":["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.6#/definitions/AccessPage"]}
+{"accessURL": "https://doi.org/10.18434/T42C7D","title": "A Library to Enable the Modeling of Optical Imaging of Finite Multi-Line Arrays","@type": [ "nrdp:AccessPage", "dcat:Distribution" ],"@id":"#10.18434/T42C7D","_extensionSchemas":["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/AccessPage"]}
 
 #--------------
 # testing dist2comp()
@@ -267,7 +267,7 @@ include "pod2nerdm"; dist2comp("doi:10.18434/T42C7D")
 #
 include "pod2nerdm"; dist2comp("doi:10.18434/T42C7D")
 {"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json", "mediaType": "application/json","title": "Titanium Boride" }
-{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.6#/definitions/DataFile"]}
+{"describedBy": "http://data.nist.gov/srd/srd_data/srd13_janaf-data-defs.json", "downloadURL": "http://data.nist.gov/srd/srd_data/srd13_B-101.json","mediaType": "application/json", "title": "Titanium Boride", "filepath":"srd13_B-101.json", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/srd13_B-101.json","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"]}
 
 #--------------
 # testing dist2comp
@@ -277,7 +277,7 @@ include "pod2nerdm"; dist2comp("doi:10.18434/T42C7D")
 #
 include "pod2nerdm"; dist2comp(null)
 {"accessURL": "http://www.nsrl.nist.gov/Downloads.htm","conformsTo": "http://www.nsrl.nist.gov/Documents/Data-Formats-of-the-NSRL-Reference-Data-Set-16.pdf","downloadURL": "http://www.nsrl.nist.gov/RDS/rds_2.50/RDS_250.iso","format": "ISO 9660 disk image","mediaType": "application/zip" }
-{"accessURL": "http://www.nsrl.nist.gov/Downloads.htm","conformsTo": "http://www.nsrl.nist.gov/Documents/Data-Formats-of-the-NSRL-Reference-Data-Set-16.pdf","downloadURL": "http://www.nsrl.nist.gov/RDS/rds_2.50/RDS_250.iso","format": { "description": "ISO 9660 disk image"},"mediaType": "application/zip", "filepath":"RDS_250.iso", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/RDS_250.iso","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.6#/definitions/DataFile"] }
+{"accessURL": "http://www.nsrl.nist.gov/Downloads.htm","conformsTo": "http://www.nsrl.nist.gov/Documents/Data-Formats-of-the-NSRL-Reference-Data-Set-16.pdf","downloadURL": "http://www.nsrl.nist.gov/RDS/rds_2.50/RDS_250.iso","format": { "description": "ISO 9660 disk image"},"mediaType": "application/zip", "filepath":"RDS_250.iso", "@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"],"@id":"cmps/RDS_250.iso","_extensionSchemas": ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"] }
 
 #--------------
 # testing dist2comp
@@ -287,7 +287,7 @@ include "pod2nerdm"; dist2comp(null)
 #
 include "pod2nerdm"; dist2comp("doi:10.18434/T42C7D")
 {"accessURL": "http://webbook.nist.gov/chemistry/","description": "Landing page for the NIST Chemistry WebBook.","mediaType": "text/html"}
-{ "accessURL": "http://webbook.nist.gov/chemistry/","description": "Landing page for the NIST Chemistry WebBook.","mediaType": "text/html","@type": ["nrdp:AccessPage","dcat:Distribution"],"@id":"#chemistry/","_extensionSchemas":["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.6#/definitions/AccessPage"]}
+{ "accessURL": "http://webbook.nist.gov/chemistry/","description": "Landing page for the NIST Chemistry WebBook.","mediaType": "text/html","@type": ["nrdp:AccessPage","dcat:Distribution"],"@id":"#chemistry/","_extensionSchemas":["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/AccessPage"]}
 
 # testing dist2comp
 #
@@ -397,13 +397,13 @@ include "pod2nerdm"; select_comp_type("nrdp:Subcollection"; "foo/bar")
 #
 include "pod2nerdm"; create_subcoll_for
 "a/b/foo"
-{"@id": "cmps/a/b/foo", "@type": ["nrdp:Subcollection"], "filepath": "a/b/foo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.6#/definitions/Subcollection" ]}
+{"@id": "cmps/a/b/foo", "@type": ["nrdp:Subcollection"], "filepath": "a/b/foo", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/Subcollection" ]}
 
 # testing insert_subcoll_comps
 #
 include "pod2nerdm"; insert_subcoll_comps
 [{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
-[{"@id": "cmps/foo/bar", "@type": ["nrdp:Subcollection"], "filepath": "foo/bar", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.6#/definitions/Subcollection" ]},{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
+[{"@id": "cmps/foo/bar", "@type": ["nrdp:Subcollection"], "filepath": "foo/bar", "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/Subcollection" ]},{ "title": "Titanium Boride", "filepath": "foo/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo", "filepath": "foo", "@type": [ "nrdp:Subcollection"]},{"title": "Titanium Boride","filepath": "foo/bar/srd13_B-101.json","@type": ["nrdp:DataFile","nrdp:DownloadableFile","dcat:Distribution"]},{ "title": "foo bar goo", "filepath": "foo/bar/goo", "@type": ["nrdp:Subcollection"]}]
 
 
 

--- a/jq/tests/test_podds2resource.py
+++ b/jq/tests/test_podds2resource.py
@@ -3,9 +3,11 @@
 import os, unittest, json, subprocess as subproc, types, pdb
 import ejsonschema as ejs
 
-nerdm = "https://data.nist.gov/od/dm/nerdm-schema/v0.6#"
-nerdmpub = "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.6#"
-nerdmbib = "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.6#"
+from nistoar.nerdm import constants as cnsts
+
+nerdm = cnsts.CORE_SCHEMA_URI+'#'
+nerdmpub = cnsts.PUB_SCHEMA_URI+'#'
+nerdmbib = cnsts.BIB_SCHEMA_URI+'#'
 datadir = os.path.join(os.path.dirname(__file__), "data")
 janaffile = os.path.join(datadir, "janaf_pod.json")
 corrfile =  os.path.join(datadir, "CORR-DATA.json")
@@ -32,8 +34,8 @@ class TestJanaf(unittest.TestCase):  #
                           {"@base": "ark:ID"} ])
                           
     def test_schema(self):
-        self.assertEquals(self.out['_schema'],
-                          "https://data.nist.gov/od/dm/nerdm-schema/v0.6#")
+        self.assertEquals(self.out['_schema'], nerdm)
+
     def test_extsch(self):
         
         exts = self.out['_extensionSchemas']
@@ -148,8 +150,8 @@ class TestCORR(unittest.TestCase):  #
                           {"@base": "ark:ID"} ])
                           
     def test_schema(self):
-        self.assertEquals(self.out['_schema'],
-                          "https://data.nist.gov/od/dm/nerdm-schema/v0.6#")
+        self.assertEquals(self.out['_schema'], nerdm)
+
     def test_extsch(self):
         
         exts = self.out['_extensionSchemas']


### PR DESCRIPTION
In addition to jq module and unit test updates, this PR also tweaks the GitHub Actions to trigger testing if updates are made to `jq/*`.
