### PR TITLE
nerdm.utils: add functions stripping features from JSON Schemas

### DIFF
--- a/docker/ejsonschema/Dockerfile
+++ b/docker/ejsonschema/Dockerfile
@@ -11,7 +11,7 @@ RUN update-alternatives --install /usr/lib/uwsgi/plugins/python3_plugin.so \
 
 RUN python -m pip install "setuptools<66.0.0"
 RUN python -m pip install json-spec jsonschema==2.4.0 requests \
-                          pytest==4.6.5 filelock crossrefapi pyyaml
+                          pytest==4.6.5 filelock crossrefapi pyyaml jsonpath_ng
 RUN python -m pip install --no-dependencies jsonmerge==1.3.0 
 
 WORKDIR /root

--- a/python/nistoar/nerdm/utils.py
+++ b/python/nistoar/nerdm/utils.py
@@ -199,7 +199,7 @@ def declutter_schema(schema: Mapping, post2020: bool=False):
         for prop in schema['properties']:
             declutter_schema(schema['properties'][prop])
 
-    deftag = "definitions" if not post2020 else "$definitions"
+    deftag = "definitions" if not post2020 else "$defs"
     if deftag in schema:
         for defname in schema[deftag]:
             declutter_schema(schema[deftag][defname])

--- a/python/tests/nistoar/nerdm/test_utils.py
+++ b/python/tests/nistoar/nerdm/test_utils.py
@@ -1,8 +1,13 @@
 import os, sys, pdb, shutil, logging, json
 import unittest as test
+from pathlib import Path
 
 from nistoar.nerdm import utils
 from nistoar.nerdm import constants as const
+
+testdir = Path(__file__).resolve().parents[0]
+basedir = testdir.parents[3]
+schemadir = basedir / 'model'
 
 class TestUtils(test.TestCase):
 
@@ -100,6 +105,91 @@ class TestUtils(test.TestCase):
         self.assertEqual(utils.cmp_versions(utils.get_nerdm_schema_version(data), "0.5"), 1)
         self.assertEqual(utils.cmp_versions(utils.get_nerdm_schema_version(data), "2.5"), -1)
         self.assertEqual(utils.cmp_versions(utils.get_nerdm_schema_version(data), "1.3"), 0)
+
+    def test_declutter_schema(self):
+        with open(schemadir/'nerdm-schema.json') as fd:
+            schema = json.load(fd)
+
+        self.assertTrue(utils.hget(schema, "title"))
+        self.assertTrue(utils.hget(schema, "description"))
+        self.assertFalse(utils.hget(schema, "definitions.Resource.title"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.description"))
+        self.assertFalse(utils.hget(schema, "definitions.Resource.notes"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.properties.title.title"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.properties.title.notes"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.properties.title.description"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.properties.title.asOntology"))
+
+        utils.declutter_schema(schema)
+
+        self.assertFalse(utils.hget(schema, "title"))
+        self.assertFalse(utils.hget(schema, "description"))
+        self.assertFalse(utils.hget(schema, "definitions.Resource.title"))
+        self.assertFalse(utils.hget(schema, "definitions.Resource.description"))
+        self.assertFalse(utils.hget(schema, "definitions.Resource.notes"))
+        self.assertFalse(utils.hget(schema, "definitions.Resource.properties.title.title"))
+        self.assertFalse(utils.hget(schema, "definitions.Resource.properties.title.notes"))
+        self.assertFalse(utils.hget(schema, "definitions.Resource.properties.title.description"))
+        self.assertFalse(utils.hget(schema, "definitions.Resource.properties.title.asOntology"))
+    
+    def test_declutter_schema_post2020(self):
+        with open(schemadir/'nerdm-schema.json') as fd:
+            schema = json.load(fd)
+
+        self.assertTrue(utils.hget(schema, "title"))
+        self.assertTrue(utils.hget(schema, "description"))
+        self.assertFalse(utils.hget(schema, "definitions.Resource.title"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.description"))
+        self.assertFalse(utils.hget(schema, "definitions.Resource.notes"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.properties.title.title"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.properties.title.notes"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.properties.title.description"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.properties.title.asOntology"))
+
+        utils.declutter_schema(schema, True)
+
+        # the file is not post-2020 compliant, so only the top level documentation will be found
+        self.assertFalse(utils.hget(schema, "title"))
+        self.assertFalse(utils.hget(schema, "description"))
+        self.assertFalse(utils.hget(schema, "definitions.Resource.title"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.description"))
+        self.assertFalse(utils.hget(schema, "definitions.Resource.notes"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.properties.title.title"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.properties.title.notes"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.properties.title.description"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.properties.title.asOntology"))
+
+    def test_unrequire_props_in(self):
+        with open(schemadir/'nerdm-schema.json') as fd:
+            schema = json.load(fd)
+
+        self.assertTrue(utils.hget(schema, "definitions.Resource.required"))
+        self.assertTrue(utils.hget(schema, "definitions.ResourceReference.allOf[1].required"))
+        self.assertTrue(utils.hget(schema, "definitions.Topic.required"))
+        self.assertTrue(utils.hget(schema, "definitions.Organization.required"))
+
+        utils.unrequire_props_in(schema, "definitions.Resource")
+        self.assertTrue(not utils.hget(schema, "definitions.Resource.required"))
+        self.assertTrue(utils.hget(schema, "definitions.ResourceReference.allOf[1].required"))
+        self.assertTrue(utils.hget(schema, "definitions.Topic.required"))
+        self.assertTrue(utils.hget(schema, "definitions.Organization.required"))
+
+        utils.unrequire_props_in(schema, ["definitions.ResourceReference"])
+        self.assertTrue(not utils.hget(schema, "definitions.Resource.required"))
+        self.assertTrue(not utils.hget(schema, "definitions.ResourceReference.allOf[1].required"))
+        self.assertTrue(utils.hget(schema, "definitions.Topic.required"))
+        self.assertTrue(utils.hget(schema, "definitions.Organization.required"))
+
+        utils.unrequire_props_in(schema, ["definitions.Resource",
+                                          "definitions.Topic",
+                                          "goober",
+                                          "definitions.Organization"])
+        self.assertTrue(not utils.hget(schema, "definitions.Resource.required"))
+        self.assertTrue(not utils.hget(schema, "definitions.ResourceReference.allOf[1].required"))
+        self.assertTrue(not utils.hget(schema, "definitions.Topic.required"))
+        self.assertTrue(not utils.hget(schema, "definitions.Organization.required"))
+        
+
     
 class TestVersion(test.TestCase):
 

--- a/python/tests/nistoar/nerdm/test_utils.py
+++ b/python/tests/nistoar/nerdm/test_utils.py
@@ -1,6 +1,7 @@
 import os, sys, pdb, shutil, logging, json
 import unittest as test
 from pathlib import Path
+from collections import OrderedDict
 
 from nistoar.nerdm import utils
 from nistoar.nerdm import constants as const
@@ -189,6 +190,46 @@ class TestUtils(test.TestCase):
         self.assertTrue(not utils.hget(schema, "definitions.Topic.required"))
         self.assertTrue(not utils.hget(schema, "definitions.Organization.required"))
         
+    def test_loosen_schema(self):
+        with open(schemadir/"nerdm-schema.json") as fd:
+            schema = json.load(fd, object_pairs_hook=OrderedDict)
+
+        self.assertTrue(utils.hget(schema, "title"))
+        self.assertTrue(utils.hget(schema, "description"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.required"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.description"))
+        self.assertTrue(utils.hget(schema, "definitions.Organization.required"))
+        self.assertTrue(utils.hget(schema, "definitions.Organization.description"))
+
+        utils.loosen_schema(schema, {"derequire": ["Resource"], "dedocument": True})
+        
+        self.assertTrue(not utils.hget(schema, "title"))
+        self.assertTrue(not utils.hget(schema, "description"))
+        self.assertTrue(not utils.hget(schema, "definitions.Resource.required"))
+        self.assertTrue(not utils.hget(schema, "definitions.Resource.description"))
+        self.assertTrue(utils.hget(schema, "definitions.Organization.required"))
+        self.assertTrue(not utils.hget(schema, "definitions.Organization.description"))
+
+    def test_loosen_schema_no_dedoc(self):
+        with open(schemadir/"nerdm-schema.json") as fd:
+            schema = json.load(fd, object_pairs_hook=OrderedDict)
+
+        self.assertTrue(utils.hget(schema, "title"))
+        self.assertTrue(utils.hget(schema, "description"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.required"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.description"))
+        self.assertTrue(utils.hget(schema, "definitions.Organization.required"))
+        self.assertTrue(utils.hget(schema, "definitions.Organization.description"))
+
+        utils.loosen_schema(schema, {"derequire": ["Resource"], "dedocument": False})
+        
+        self.assertTrue(utils.hget(schema, "title"))
+        self.assertTrue(utils.hget(schema, "description"))
+        self.assertTrue(not utils.hget(schema, "definitions.Resource.required"))
+        self.assertTrue(utils.hget(schema, "definitions.Resource.description"))
+        self.assertTrue(utils.hget(schema, "definitions.Organization.required"))
+        self.assertTrue(utils.hget(schema, "definitions.Organization.description"))
+
 
     
 class TestVersion(test.TestCase):

--- a/scripts/makedist.nerdmdocs
+++ b/scripts/makedist.nerdmdocs
@@ -78,8 +78,8 @@ echo '+' PACKAGE_NAME=$PACKAGE_NAME
 echo '+' version=$version
 
 # build the components
+# set -x
 installdir=$BUILD_DIR/docs
-set -x
 mkdir -p $installdir
 
 # export schema files

--- a/scripts/record_deps.py
+++ b/scripts/record_deps.py
@@ -12,7 +12,7 @@
 # The default package name (oar-sdp) can be over-ridden by the environment
 # variable PACKAGE_NAME
 #
-import os, sys, json, re
+import os, sys, json, re, traceback as tb
 from collections import OrderedDict
 
 prog = os.path.basename(sys.argv[0])
@@ -80,17 +80,23 @@ def ejschemadep():
 
 def jmergedep():
     import jsonmerge
-    eggre = re.compile(r'^jsonmerge-(.*)\.egg-info$')
+    eggre = re.compile(r'^jsonmerge-(.*)\.egg')
     modfile = jsonmerge.__file__
     libdir = os.path.dirname(os.path.dirname(modfile))
     vers="(unknown)"
-    try:
-        egginfo = [d for d in os.listdir(libdir) if eggre.match(d)]
-        if len(egginfo) > 0:
-            m = eggre.match(egginfo[0])
-            vers = m.group(1)
-    except Exception as ex:
-        tb.print_exc()
+    m = eggre.match(os.path.basename(libdir))
+    if m:
+        # zipped egg
+        vers = m.group(1)
+    else:
+        # it's the dist-packages dir; look for the egg-info file
+        try:
+            egginfo = [d for d in os.listdir(libdir) if eggre.match(d)]
+            if len(egginfo) > 0:
+                m = eggre.match(egginfo[0])
+                vers = m.group(1)
+        except Exception as ex:
+            tb.print_exc()
     return OrderedDict([
         ("name", "jsonmerge"),
         ("version", vers)


### PR DESCRIPTION
This PR provides functions for stripping features from a JSON Schema, making them more lenient.  This is used by the DAP implementation in oar-pdr-py for validating updates to draft publications.  

This is best tested via [oar-pdr-py PR# 4](https://github.com/usnistgov/oar-pdr-py/pull/4).
