### PR TITLE
Fix MongoDB Signature Key Issue and Resolution

### DIFF
--- a/docker/pymongo/Dockerfile
+++ b/docker/pymongo/Dockerfile
@@ -1,12 +1,25 @@
 # This provides the base support for Python 3.8 and MongoDB 4.4 
 
-FROM mongo:4.4
+FROM ubuntu:focal
 # VOLUME /data
 MAINTAINER Ray Plante <raymond.plante@nist.gov>
 COPY mongod.conf /etc/mongod.conf
 COPY mongod_ctl.sh /usr/local/bin
 
+# Set the timezone to stop tcaza package from hanging
+ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && apt-get install -y gnupg curl
+
+# Add the MongoDB GPG key
+RUN curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add -
+
+# Add MongoDB repository
+RUN echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.4.list
+    
 RUN apt-get update && apt-get install -y ca-certificates locales python3.8 python3-pip python3.8-dev
+
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1; \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1; \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
@@ -20,4 +33,3 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 RUN python -m pip install pymongo
-


### PR DESCRIPTION
The build process for the **pymongo** Docker image fails due to an expired MongoDB signature key. My guess is that the base image **mongo:4.4** is using an expired key, which causes the **apt-get update** step to fail. This error also prevents Python 3 from being installed, which causes the overall component (**ingestdata**) build to fail. 

Error log:

```sh
Step 1/14 : FROM mongo:4.4
4.4: Pulling from library/mongo
d7044108e6d4: Already exists
001b287048bd: Pulling fs layer
1dff8d23fd24: Pulling fs layer
ff1737f9e3a7: Pulling fs layer
11a98d2a6710: Pulling fs layer
b02d9073ec97: Pulling fs layer
43f280ad780e: Pulling fs layer
ba79d65b2323: Pulling fs layer
b02d9073ec97: Waiting
43f280ad780e: Waiting
ba79d65b2323: Waiting
11a98d2a6710: Waiting
001b287048bd: Verifying Checksum
001b287048bd: Download complete
001b287048bd: Pull complete
ff1737f9e3a7: Verifying Checksum
ff1737f9e3a7: Download complete
1dff8d23fd24: Verifying Checksum
1dff8d23fd24: Download complete
11a98d2a6710: Download complete
b02d9073ec97: Verifying Checksum
b02d9073ec97: Download complete
1dff8d23fd24: Pull complete
ff1737f9e3a7: Pull complete
11a98d2a6710: Pull complete
b02d9073ec97: Pull complete
ba79d65b2323: Verifying Checksum
ba79d65b2323: Download complete
43f280ad780e: Verifying Checksum
43f280ad780e: Download complete
43f280ad780e: Pull complete
ba79d65b2323: Pull complete
Digest: sha256:52c42cbab240b3c5b1748582cc13ef46d521ddacae002bbbda645cebed270ec0
Status: Downloaded newer image for mongo:4.4
 ---> 80d502872ebd
Step 2/14 : MAINTAINER Ray Plante <raymond.plante@nist.gov>
 ---> Running in 44a3865847e7
 ---> Removed intermediate container 44a3865847e7
 ---> 8e7b39ee36a1
Step 3/14 : COPY mongod.conf /etc/mongod.conf
 ---> 38e52ac907fd
Step 4/14 : COPY mongod_ctl.sh /usr/local/bin
 ---> bbe339093039
Step 5/14 : RUN apt-get update && apt-get install -y ca-certificates locales python3.8 python3-pip python3.8-dev
 ---> Running in 778a1b0b7e15
Ign:1 http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 InRelease
Get:2 http://ports.ubuntu.com/ubuntu-ports focal InRelease [265 kB]
Get:3 http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 Release [3094 B]
Get:4 http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 Release.gpg [866 B]
Ign:4 http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 Release.gpg
Get:5 http://ports.ubuntu.com/ubuntu-ports focal-updates InRelease [128 kB]
Get:6 http://ports.ubuntu.com/ubuntu-ports focal-backports InRelease [128 kB]
Get:7 http://ports.ubuntu.com/ubuntu-ports focal-security InRelease [128 kB]
Get:8 http://ports.ubuntu.com/ubuntu-ports focal/universe arm64 Packages [11.1 MB]
Get:9 http://ports.ubuntu.com/ubuntu-ports focal/restricted arm64 Packages [1317 B]
Get:10 http://ports.ubuntu.com/ubuntu-ports focal/main arm64 Packages [1234 kB]
Get:11 http://ports.ubuntu.com/ubuntu-ports focal/multiverse arm64 Packages [139 kB]
Get:12 http://ports.ubuntu.com/ubuntu-ports focal-updates/multiverse arm64 Packages [10.7 kB]
Get:13 http://ports.ubuntu.com/ubuntu-ports focal-updates/restricted arm64 Packages [52.3 kB]
Get:14 http://ports.ubuntu.com/ubuntu-ports focal-updates/main arm64 Packages [3191 kB]
Get:15 http://ports.ubuntu.com/ubuntu-ports focal-updates/universe arm64 Packages [1412 kB]
Get:16 http://ports.ubuntu.com/ubuntu-ports focal-backports/main arm64 Packages [54.8 kB]
Get:17 http://ports.ubuntu.com/ubuntu-ports focal-backports/universe arm64 Packages [27.8 kB]
Get:18 http://ports.ubuntu.com/ubuntu-ports focal-security/multiverse arm64 Packages [4661 B]
Get:19 http://ports.ubuntu.com/ubuntu-ports focal-security/restricted arm64 Packages [52.0 kB]
Get:20 http://ports.ubuntu.com/ubuntu-ports focal-security/universe arm64 Packages [1113 kB]
Get:21 http://ports.ubuntu.com/ubuntu-ports focal-security/main arm64 Packages [2811 kB]
Reading package lists...
W: GPG error: http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 Release: The following signatures were invalid: EXPKEYSIG 656408E390CFB1F5 MongoDB 4.4 Release Signing Key <packaging@mongodb.com>
E: The repository 'http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 Release' is not signed.
The command '/bin/sh -c apt-get update && apt-get install -y ca-certificates locales python3.8 python3-pip python3.8-dev' returned a non-zero code: 100
...
...
localbuild: The following components failed to build:
localbuild:   oar-metadata: build failure: Failed to build components from oar-metadata
localbuild: Some components not available due to build failures
localdeploy: One or more needed components failed to build
```

To resolve this issue, I switched the base image to **ubuntu:focal**, the same base image **mongo:4.4** uses, and I manually:
- added the MongoDB key:

```sh
curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add -
```

-  installed MongoDB 4.4:

```sh
echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.4.list
```

Note that [MongoDB 4.4 is past its end of life cycle as of February 2024](https://www.mongodb.com/legal/support-policy/lifecycles). I think it is better to upgrade to a more recent version of MongoDB.

The following is a [workaround](https://dev.to/grigorkh/fix-tzdata-hangs-during-docker-image-build-4o9m) for an issue with **tzdata** hanging during installation

```sh
ENV TZ=America/New_York
RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
```

These changes seem to fix the issue and the build is successful.