### PR TITLE
Update docker to Ubuntu 22, Python 3.10, MongoDB 7.0

### DIFF
--- a/docker/ejsonschema/Dockerfile
+++ b/docker/ejsonschema/Dockerfile
@@ -2,12 +2,12 @@ FROM oar-metadata/jqfromsrc:latest
 
 RUN apt-get update && apt-get install -y unzip uwsgi uwsgi-src \
                                          uuid-dev libcap-dev libpcre3-dev python3-distutils
-RUN PYTHON=python3.8 uwsgi --build-plugin "/usr/src/uwsgi/plugins/python python38" && \
-    mv python38_plugin.so /usr/lib/uwsgi/plugins/python38_plugin.so && \
-    chmod 644 /usr/lib/uwsgi/plugins/python38_plugin.so
+RUN PYTHON=python3 uwsgi --build-plugin "/usr/src/uwsgi/plugins/python python3" && \
+    mv python3_plugin.so /usr/lib/uwsgi/plugins/python3_plugin.so && \
+    chmod 644 /usr/lib/uwsgi/plugins/python3_plugin.so
 
-RUN update-alternatives --install /usr/lib/uwsgi/plugins/python3_plugin.so \
-    python_plugin.so /usr/lib/uwsgi/plugins/python38_plugin.so 1
+RUN update-alternatives --install /usr/lib/uwsgi/plugins/python_plugin.so \
+    python_plugin.so /usr/lib/uwsgi/plugins/python3_plugin.so 1
 
 RUN python -m pip install "setuptools<66.0.0"
 RUN python -m pip install json-spec jsonschema==2.4.0 requests \
@@ -17,16 +17,16 @@ RUN python -m pip install --no-dependencies jsonmerge==1.3.0
 WORKDIR /root
 
 RUN curl -L -o ejsonschema.zip \
-    https://github.com/usnistgov/ejsonschema/archive/master.zip && \
+    https://github.com/usnistgov/ejsonschema/archive/1.0rc4.zip && \
     unzip ejsonschema.zip && \
-    cd ejsonschema-master && \
-    python setup.py install --install-purelib=/usr/local/lib/python3.8/dist-packages
+    cd ejsonschema-1.0rc4 && \
+    python setup.py install --install-purelib=/usr/local/lib/python3.10/dist-packages
 
 RUN curl -L -o pynoid.zip \
     https://github.com/RayPlante/pynoid/archive/master.zip && \
     unzip pynoid.zip && \
     cd pynoid-master && \
-    python setup.py install --install-purelib=/usr/local/lib/python3.8/dist-packages
+    python setup.py install --install-purelib=/usr/local/lib/python3.10/dist-packages
 
 CMD ["bash"]
 

--- a/docker/pymongo/Dockerfile
+++ b/docker/pymongo/Dockerfile
@@ -1,14 +1,15 @@
 # This provides the base support for Python 3.8 and MongoDB 4.4 
 
-FROM mongo:4.4
+FROM mongo:7.0-jammy
 # VOLUME /data
 MAINTAINER Ray Plante <raymond.plante@nist.gov>
 COPY mongod.conf /etc/mongod.conf
 COPY mongod_ctl.sh /usr/local/bin
 
-RUN apt-get update && apt-get install -y ca-certificates locales python3.8 python3-pip python3.8-dev
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1; \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1; \
+RUN apt-get update && apt-get install -y ca-certificates locales \
+                                         python3 python3-pip python3-dev python-is-python3
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1; \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3 1; \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 RUN locale-gen en_US.UTF-8
 

--- a/docker/pymongo/Dockerfile
+++ b/docker/pymongo/Dockerfile
@@ -1,4 +1,4 @@
-# This provides the base support for Python 3.8 and MongoDB 4.4 
+# This provides the base support for Python 3.10 and MongoDB 7.0
 
 FROM mongo:7.0-jammy
 # VOLUME /data

--- a/python/nistoar/doi/datacite.py
+++ b/python/nistoar/doi/datacite.py
@@ -7,7 +7,8 @@ DataCite DOIs with a focus on creating them and updating their metadata via
 DataCite services.  
 """
 import re
-from collections import OrderedDict, Mapping
+from collections import OrderedDict
+from collections.abc import Mapping
 from copy import deepcopy
 from io import StringIO
 import requests

--- a/python/nistoar/id/persist.py
+++ b/python/nistoar/id/persist.py
@@ -4,7 +4,8 @@ its IDs and related data to a file on disk.  This implementation provides
 locking to prevent two processes from acquiring the same ID.
 """
 import os, logging, json
-from collections import Mapping
+from collections import OrderedDict
+from collections.abc import Mapping
 from copy import deepcopy
 from .minter import IDRegistry, IDMinter, NoidMinter, NIST_ARK_NAAN
 import pynoid as noid, filelock

--- a/python/nistoar/nerdm/convert/latest.py
+++ b/python/nistoar/nerdm/convert/latest.py
@@ -2,7 +2,8 @@
 Module for converting a NERDm record to the latest schema versions.  
 """
 import re
-from collections import OrderedDict, Mapping
+from collections import OrderedDict
+from collections.abc import Mapping
 from copy import deepcopy
 from urllib.parse import urlparse
 

--- a/python/nistoar/nerdm/convert/pod.py
+++ b/python/nistoar/nerdm/convert/pod.py
@@ -2,7 +2,8 @@
 Classes and functions for converting from and to the NERDm schema
 """
 import os, json, re
-from collections import OrderedDict, Mapping
+from collections import OrderedDict
+from collections.abc import Mapping
 
 from ... import jq
 from ...doi import resolve, is_DOI

--- a/python/nistoar/nerdm/convert/rmm.py
+++ b/python/nistoar/nerdm/convert/rmm.py
@@ -17,7 +17,8 @@ The RMM includes three relevant collections:
                        as a version-specific ID.
 """
 import re
-from collections import OrderedDict, Mapping
+from collections import OrderedDict
+from collections.abc import Mapping
 from urllib.parse import urljoin
 from copy import deepcopy
 

--- a/python/nistoar/nerdm/validate.py
+++ b/python/nistoar/nerdm/validate.py
@@ -1,7 +1,8 @@
 """
 tools for validating NERDm metadata
 """
-from collections import Mapping
+from collections import OrderedDict
+from collections.abc import Mapping
 
 import ejsonschema as ejs
 from ejsonschema import ValidationError, RefResolutionError

--- a/python/nistoar/rmm/mongo/nerdm.py
+++ b/python/nistoar/rmm/mongo/nerdm.py
@@ -3,7 +3,8 @@ load NERDm records into the RMM's MongoDB database
 """
 # import pandas as pd
 import json, os, sys, warnings
-from collections import Mapping
+from collections import OrderedDict
+from collections.abc import Mapping
 
 from .loader import (Loader, RecordIngestError, JSONEncodingError,
                      UpdateWarning, LoadLog)

--- a/python/tests/nistoar/doi/resolving/test_crossref.py
+++ b/python/tests/nistoar/doi/resolving/test_crossref.py
@@ -1,6 +1,6 @@
 import os, sys, pdb, shutil, logging, json
 import unittest as test
-from collections import Mapping
+from collections.abc import Mapping
 # from nistoar.tests import *
 
 import nistoar.doi.resolving.crossref as res

--- a/python/tests/nistoar/doi/resolving/test_datacite.py
+++ b/python/tests/nistoar/doi/resolving/test_datacite.py
@@ -1,6 +1,6 @@
 import os, sys, pdb, shutil, logging, json
 import unittest as test
-from collections import Mapping
+from collections.abc import Mapping
 # from nistoar.tests import *
 
 import nistoar.doi.resolving.datacite as res

--- a/python/tests/nistoar/doi/sim_datacite_srv.py
+++ b/python/tests/nistoar/doi/sim_datacite_srv.py
@@ -1,7 +1,8 @@
 import json, os, sys, re, hashlib, json, logging, random
 from datetime import datetime
 from wsgiref.headers import Headers
-from collections import OrderedDict, Mapping
+from collections import OrderedDict
+from collections.abc import Mapping
 from copy import deepcopy
 from urllib.parse import parse_qs
 

--- a/python/tests/nistoar/nerdm/test_validate.py
+++ b/python/tests/nistoar/nerdm/test_validate.py
@@ -1,5 +1,5 @@
 import unittest, pdb, os, json
-from collections import Mapping
+from collections.abc import Mapping
 
 import ejsonschema as ejs
 


### PR DESCRIPTION
The environment established within the docker containers represent the canonical environment that the software is tested against as part of continuous integration and should provide dependencies matching the production environment.  In this PR, three key dependencies are upgraded:
  * OS: Ubuntu 22.04
  * Python 3.10
  * MongoDB 7.0

This upgrade was motivated by a need to upgrade MongoDB from 4.4 which is losing support.  This triggered the need to update the Ubuntu version (from 20) which comes with a higher version of Python (up from 3.9).  The python code was found still to contain some deprecated imports, which were corrected.  We note that the updates were needed of the ejsonschema and multibag python libraries.


