### PR TITLE
nistoar.base.logging.server:  a logging server for replicated services

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/testall.yml
+++ b/.github/workflows/testall.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1

--- a/docker/mdenv/Dockerfile
+++ b/docker/mdenv/Dockerfile
@@ -13,7 +13,7 @@ ENV OAR_UWSGI_OPTS="--ini /usr/share/uwsgi/conf/mdenv.ini"
 
 RUN python -m pip install --upgrade "setuptools>=61.0.0,<66.0.0" pip
 RUN apt-get remove -y python3-setuptools
-RUN python -m pip install json-spec jsonschema==2.4.0 requests \
+RUN python -m pip install json-spec jsonschema==2.4.0 requests psutil \
                           pytest==4.6.5 filelock crossrefapi pyyaml jsonpath_ng
 RUN python -m pip install --no-dependencies jsonmerge==1.3.0 
 

--- a/python/nistoar/base/config.py
+++ b/python/nistoar/base/config.py
@@ -90,7 +90,10 @@ def load_from_file(configfile: str) -> Mapping:
             # YAML format
             return yaml.safe_load(fd)
 
-LOG_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
+FILE_LOG_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
+CONSOLE_LOG_FORMAT = "%(name)s: %(levelname)s %(message)s"
+SERVER_LOG_FORMAT = "%(asctime)s (%(process)d) %(name)s %(levelname)s: %(message)s"
+LOG_FORMAT = FILE_LOG_FORMAT
 global_logdir = None         # this is set when configure_log() is run
 global_logfile = None        # this is set when configure_log() is run
 _log_levels_byname = {
@@ -184,10 +187,10 @@ _logging_defaults = {
     "version": 1,
     "formatters": {
         "file": {
-            "format": LOG_FORMAT
+            "format": FILE_LOG_FORMAT
         },
         "console": {
-            "format": "%(name)s: %(levelname)s %(message)s"
+            "format": CONSOLE_LOG_FORMAT
         }
     },
     "handlers": {

--- a/python/nistoar/base/config.py
+++ b/python/nistoar/base/config.py
@@ -2,10 +2,12 @@
 Utilities for obtaining configuration data for services
 """
 
-import os, sys, logging, json, yaml, time, re
+import os, sys, json, yaml, time, re
+import logging, logging.handlers, logging.config
 import requests
 from collections.abc import Mapping
 from urllib.parse import urlparse
+from copy import deepcopy
 
 import jsonpath_ng as jp
 
@@ -89,7 +91,6 @@ def load_from_file(configfile: str) -> Mapping:
             return yaml.safe_load(fd)
 
 LOG_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
-_log_handler = None
 global_logdir = None         # this is set when configure_log() is run
 global_logfile = None        # this is set when configure_log() is run
 _log_levels_byname = {
@@ -105,6 +106,206 @@ _log_levels_byname = {
 }
 NORMAL = _log_levels_byname["NORMAL"]
 
+def configure_logging(config: Mapping, addstderr=False):
+    """
+    configure logging for an OAR application using parameters from the given configuration 
+    dictionary.  Additional function arguments will over-ride the configuration.
+
+    This function deprecates :py:func:`configure_log` to be more driven by the configuration
+    dictionary.  (See also :py:func:`configure_file_logging`.)
+
+    The given configuration dictionary should conform to on of two schemas.  First, if the 
+    dictionary includes ``logging``, it will be taken as configuration dictionary supported 
+    by the standard Python logging.config module function, ``dictConfig()``; all other 
+    logging parameters will be ignored--except ``logdir``.  If the latter is also provided,
+    then any non-absolute filename destinations will be treated as relative to the value
+    of ``logdir``.  
+
+    Alternatively, the configuration can contain the following parameters:
+
+    ``logserver``:
+        (str) *optional*.  Log messages should be sent to a logging service at the location
+        given by this value, of the form HOST:PORT.
+    ``logfile``:
+        (str) *optional*.  Log messages should be sent to a file with this name.  If the 
+        given path is non-absolute, it will be interpreted as relative to the value of 
+        ``logdir``.  Note that normally, this is not set if ``logserver`` is specified, 
+        but it is allowed.  
+    ``logdir``
+        (str) *optional*.  The directory that should contain log files whose paths are not 
+        specified as absolute.  
+    ``loglevel``
+        (str or int) *optional*.  The logging level to apply to the log-server and
+        file output handlers.  If given as a string, it should correspond to one of the 
+        standard logging module level labels; in addition, "NORMAL" and "NOTSET" are 
+        also supported.  
+    ``loglevelsfor``
+        (dict) *optional*.  Logging level filters to apply to named loggers.  This can 
+        be used to quiet (or louden) messages from third-party modules.  Each key is a 
+        logger name, and the value is a string or integer level.  
+
+    :param dict config:  a configuration dictionary to draw logging configuration
+                         values from.  
+    :param addstderr:    If True, send ERROR and more severe messages 
+                         to the standard error stream (default: False).  If 
+                         provided as a str, it is the formatting string for 
+                         messages sent to standard error.
+                         :type  addstderr:    bool or str
+    """
+    global global_logdir
+    global global_logfile
+
+    if config.get('logging'):
+        logcfg = config['logging']
+
+        # if logdir is set, make log filenames relative to it
+        global_logdir = config.get('logdir', determine_default_logdir())
+        if global_logdir:
+            logcfg = deepcopy(logcfg)
+            if not os.path.exists(global_logdir):
+                os.makedirs(global_logdir)
+            for hdlr in logging.get('handlers', {}).values():
+                if not isinstace(hdlr, Mapping):
+                    continue
+                if hdlr.get('filename') and not os.path.isabs(hdlr['filename']):
+                    hdlr['filename'] = os.path.join(global_logdir, hdlr['filename'])
+        
+        logging.dictConfig(logcfg)
+
+        ignored = [p for p in "logfile loglevel logformat loglevelsfor".split() if p in config]
+        if ignored:
+            logging.warn("Config parameter logging causes these parameters to be ignored:\n  "+
+                         "  \n".join(ignored))
+
+    else:
+        _configure_log(config=config)
+
+_logging_defaults = {
+    "version": 1,
+    "formatters": {
+        "file": {
+            "format": LOG_FORMAT
+        },
+        "console": {
+            "format": "%(name)s: %(levelname)s %(message)s"
+        }
+    },
+    "handlers": {
+        "file": {
+            "class": "logging.FileHandler",
+            "formatter": "file"
+        },
+        "logserver": {
+            "class": "logging.handlers.SocketHandler",
+            "host": "localhost",
+            "port":  logging.handlers.DEFAULT_TCP_LOGGING_PORT
+        },
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "console",
+            "level": "ERROR",
+            "stream": sys.stderr
+        }
+    },
+    "loggers": {
+    }
+}
+
+def _configure_log(logfile: str=None, level: int=None, format: str=None, config: Mapping=None,
+                   addstderr=False):
+    global global_logdir
+    global global_logfile
+    def get_formatter(name, fromcfg=_logging_defaults):
+        return fromcfg.get("formatters", {}).get(name)
+    def get_handler(name, fromcfg=_logging_defaults):
+        return fromcfg.get("handlers", {}).get(name)
+
+    if not config:
+        confit = {}
+    if not logfile and (not config.get('logserver') or config.get('logfile')):
+        logfile = config.get('logfile', 'pdr.log')
+
+    if level is None:
+        level = config.get('loglevel', logging.DEBUG)
+    if not isinstance(level, int):
+        level = _log_levels_byname.get(str(level), level)
+    if not isinstance(level, int):
+        raise ConfigurationException("Unrecognized loglevel value: "+str(level))
+
+    if not format:
+        format = config.get('logformat', LOG_FORMAT)
+
+    fmttrs = { "file": deepcopy(get_formatter("file")) }
+    if format:
+        fmttrs["file"]["format"] = format
+
+    hndlrs = { }
+    if config.get('logserver'):
+        hndlrs['logserver'] = deepcopy(get_handler('logserver'))
+        hostport = config['logserver'].split(':')
+        hndlrs['logserver']['host'] = hostport[0]
+        if len(hostport) > 1:
+            hndlrs['logserver']['port'] = hostport[1]
+        hndlrs['logserver']['level'] = level
+
+    elif not logfile:
+        logfile = config.get('logfile', 'pdr.log')
+
+    if logfile:
+        # Note: you probably don't want both logserver and logfile specified
+
+        if not os.path.isabs(logfile):
+            # The log directory can be set either from the configuration or via
+            # the OAR_LOG_DIR environment variable; the former takes precedence
+            global_logdir = config.get('logdir', determine_default_logdir())
+            logfile = os.path.join(global_logdir, logfile)
+            if not os.path.exists(os.path.dirname(logfile)):
+                os.makedirs(os.path.dirname(logfile))
+
+        hndlrs['file'] = deepcopy(get_handler("file"))
+        hndlrs['file']['filename'] = logfile
+        hndlrs['file']['level'] = level
+        global_logfile = logfile
+
+    if addstderr:
+        hndlrs['console'] = deepcopy(get_handler("console"))
+            
+    logcfg = {
+        "version": 1,
+        "formatters": fmttrs,
+        "handlers": hndlrs,
+        "root": {
+            "level": logging.DEBUG-1
+        },
+        "loggers": {}
+    }
+
+    _quiet_loggers(logcfg['loggers'], config.get('loglevelsfor'), level, True)
+
+    logcfg['root']['handlers'] = list(logcfg['handlers'].keys())
+
+    logging.config.dictConfig(logcfg)
+
+
+def _quiet_loggers(lgscfg, levelsfor, deflev, auto=True):
+
+    if levelsfor and isinstance(levelsfor, Mapping):
+        for lognm, level in levelsfor.items():
+            if not isinstance(level, int):
+                level = _log_levels_byname.get(str(level), level)
+            if isinstance(level, int):
+                lgscfg[lognm] = { "level": level }
+
+    if auto:
+        # jsonmerge is way too chatty at the DEBUG level
+        if deflev >= logging.DEBUG:
+            jmlevel = max(deflev, logging.INFO)
+            lgscfg["jsonmerge"] = { "level": jmlevel }
+
+        # filelock is one level too chatty
+        if deflev >= logging.DEBUG:
+            lgscfg["filelock"] = { "level": deflev+10 }
+
 def configure_log(logfile: str=None, level: int=None, format: str=None, config: Mapping=None,
                   addstderr=False):
     """
@@ -112,8 +313,13 @@ def configure_log(logfile: str=None, level: int=None, format: str=None, config: 
     as necessary.  These can be provided explicitly or provided via the 
     configuration; the former takes precedence.  
 
+    This function is deprecated by :py:function:`configure_logging`.
+
     If this is called a second time, it will first close the previously opened logfile, 
     reconfigure the logging to given inputs.  
+
+    See :py:func:`configure_logging` for a description of the configuration parameters looked 
+    for.  
 
     :param str logfile:  the path to the output logfile.  If given as a relative
                          path, it will be assumed that it is relative to a 
@@ -129,73 +335,76 @@ def configure_log(logfile: str=None, level: int=None, format: str=None, config: 
                          messages sent to standard error.
     :type  addstderr:    bool or str
     """
-    global global_logdir
-    global global_logfile
-    if not config:
-        config = {}
-    if not logfile:
-        logfile = config.get('logfile', 'pdr.log')
+    _configure_log(logfile, level, format, config, addstderr)
+    logging.warning("Use of configure_log() is deprecated; use configure_logging()")
 
-    if not os.path.isabs(logfile):
-        # The log directory can be set either from the configuration or via
-        # the OAR_LOG_DIR environment variable; the former takes precedence
-        deflogdir = os.path.join(oar_home,'var','logs')
-        logdir = config.get('logdir', determine_default_logdir())
-        global_logdir = logdir
-        logfile = os.path.join(logdir, logfile)
-        if not os.path.exists(os.path.dirname(logfile)):
-            os.makedirs(os.path.dirname(logfile))
-    global_logfile = logfile
+    # global global_logdir
+    # global global_logfile
+    # if not config:
+    #     config = {}
+    # if not logfile:
+    #     logfile = config.get('logfile', 'pdr.log')
+
+    # if not os.path.isabs(logfile):
+    #     # The log directory can be set either from the configuration or via
+    #     # the OAR_LOG_DIR environment variable; the former takes precedence
+    #     deflogdir = os.path.join(oar_home,'var','logs')
+    #     logdir = config.get('logdir', determine_default_logdir())
+    #     global_logdir = logdir
+    #     logfile = os.path.join(logdir, logfile)
+    #     if not os.path.exists(os.path.dirname(logfile)):
+    #         os.makedirs(os.path.dirname(logfile))
+    # global_logfile = logfile
     
-    if level is None:
-        level = config.get('loglevel', logging.DEBUG)
-    if not isinstance(level, int):
-        level = _log_levels_byname.get(str(level), level)
-    if not isinstance(level, int):
-        raise ConfigurationException("Unrecognized loglevel value: "+str(level))
+    # if level is None:
+    #     level = config.get('loglevel', logging.DEBUG)
+    # if not isinstance(level, int):
+    #     level = _log_levels_byname.get(str(level), level)
+    # if not isinstance(level, int):
+    #     raise ConfigurationException("Unrecognized loglevel value: "+str(level))
 
-    if not format:
-        format = config.get('logformat', LOG_FORMAT)
-    frmtr = logging.Formatter(format)
+    # if not format:
+    #     format = config.get('logformat', LOG_FORMAT)
+    # frmtr = logging.Formatter(format)
 
-    global _log_handler
-    rootlogger = logging.getLogger()
-    if _log_handler:
-        rootlogger.removeHandler(_log_handler)
-        if hasattr(_log_handler, 'close'):
-            _log_handler.close()
-        _log_handler = None
-    _log_handler = logging.FileHandler(logfile)
-    _log_handler.setLevel(level)
-    _log_handler.setFormatter(frmtr)
-    rootlogger.addHandler(_log_handler)
-    rootlogger.setLevel(logging.DEBUG-1)
+    # global _log_handler
+    # rootlogger = logging.getLogger()
+    # if _log_handler:
+    #     rootlogger.removeHandler(_log_handler)
+    #     if hasattr(_log_handler, 'close'):
+    #         _log_handler.close()
+    #     _log_handler = None
+    # _log_handler = logging.FileHandler(logfile)
+    # _log_handler.setLevel(level)
+    # _log_handler.setFormatter(frmtr)
+    # rootlogger.addHandler(_log_handler)
+    # rootlogger.setLevel(logging.DEBUG-1)
 
-    # jsonmerge is way too chatty at the DEBUG level
-    if level >= logging.DEBUG:
-        jmlevel = max(level, logging.INFO)
-        logging.getLogger("jsonmerge").setLevel(jmlevel)
+    # # jsonmerge is way too chatty at the DEBUG level
+    # if level >= logging.DEBUG:
+    #     jmlevel = max(level, logging.INFO)
+    #     logging.getLogger("jsonmerge").setLevel(jmlevel)
 
-    # filelock is one level too chatty
-    if level >= logging.DEBUG:
-        logging.getLogger("filelock").setLevel(level+10)
+    # # filelock is one level too chatty
+    # if level >= logging.DEBUG:
+    #     logging.getLogger("filelock").setLevel(level+10)
 
-    # config can set levels on a per-logname basis
-    if config.get("loglevelsfor") and isinstance(config.get("loglevelsfor"), Mapping):
-        for lognm, level in config.get("loglevelsfor", {}).items():
-            if not isinstance(level, int):
-                level = _log_levels_byname.get(str(level), level)
-            if isinstance(level, int):
-                logging.getLogger(lognm).setLevel(level)
+    # # config can set levels on a per-logname basis
+    # if config.get("loglevelsfor") and isinstance(config.get("loglevelsfor"), Mapping):
+    #     for lognm, level in config.get("loglevelsfor", {}).items():
+    #         if not isinstance(level, int):
+    #             level = _log_levels_byname.get(str(level), level)
+    #         if isinstance(level, int):
+    #             logging.getLogger(lognm).setLevel(level)
     
-    if addstderr:
-        if not isinstance(addstderr, str):
-            addstderr = format
-        handler = logging.StreamHandler(sys.stderr)
-        handler.setLevel(logging.ERROR)
-        handler.setFormatter(logging.Formatter(addstderr))
-        rootlogger.addHandler(handler)
-        rootlogger.error("FYI: Writing log messages to %s",logfile)
+    # if addstderr:
+    #     if not isinstance(addstderr, str):
+    #         addstderr = format
+    #     handler = logging.StreamHandler(sys.stderr)
+    #     handler.setLevel(logging.ERROR)
+    #     handler.setFormatter(logging.Formatter(addstderr))
+    #     rootlogger.addHandler(handler)
+    #     rootlogger.error("FYI: Writing log messages to %s",logfile)
 
 def determine_default_logdir():
     out = os.environ.get('OAR_LOG_DIR', os.path.join(oar_home, 'var', 'logs'))

--- a/python/nistoar/base/config.py
+++ b/python/nistoar/base/config.py
@@ -204,7 +204,7 @@ _logging_defaults = {
             "class": "logging.StreamHandler",
             "formatter": "console",
             "level": "ERROR",
-            "stream": sys.stderr
+            "stream": "ext://sys.stderr"
         }
     },
     "loggers": {
@@ -268,6 +268,7 @@ def _configure_log(logfile: str=None, level: int=None, format: str=None, config:
         global_logfile = logfile
 
     if addstderr:
+        fmttrs['console'] = deepcopy(get_formatter("console"))
         hndlrs['console'] = deepcopy(get_handler("console"))
             
     logcfg = {

--- a/python/nistoar/base/config.py
+++ b/python/nistoar/base/config.py
@@ -96,8 +96,10 @@ SERVER_LOG_FORMAT = "%(asctime)s (%(process)d) %(name)s %(levelname)s: %(message
 LOG_FORMAT = FILE_LOG_FORMAT
 global_logdir = None         # this is set when configure_log() is run
 global_logfile = None        # this is set when configure_log() is run
+TRACE = logging.DEBUG - 2
 _log_levels_byname = {
     "NOTSET":   logging.NOTSET,
+    "TRACE":    TRACE,
     "DEBUG":    logging.DEBUG,
     "NORM":     15,
     "NORMAL":   15,

--- a/python/nistoar/base/config.py
+++ b/python/nistoar/base/config.py
@@ -226,7 +226,7 @@ def _configure_log(logfile: str=None, level: int=None, format: str=None, config:
         return fromcfg.get("handlers", {}).get(name)
 
     if not config:
-        confit = {}
+        config = {}
     if not logfile and (not config.get('logserver') or config.get('logfile')):
         logfile = config.get('logfile', 'pdr.log')
 
@@ -343,74 +343,6 @@ def configure_log(logfile: str=None, level: int=None, format: str=None, config: 
     """
     _configure_log(logfile, level, format, config, addstderr)
     logging.warning("Use of configure_log() is deprecated; use configure_logging()")
-
-    # global global_logdir
-    # global global_logfile
-    # if not config:
-    #     config = {}
-    # if not logfile:
-    #     logfile = config.get('logfile', 'pdr.log')
-
-    # if not os.path.isabs(logfile):
-    #     # The log directory can be set either from the configuration or via
-    #     # the OAR_LOG_DIR environment variable; the former takes precedence
-    #     deflogdir = os.path.join(oar_home,'var','logs')
-    #     logdir = config.get('logdir', determine_default_logdir())
-    #     global_logdir = logdir
-    #     logfile = os.path.join(logdir, logfile)
-    #     if not os.path.exists(os.path.dirname(logfile)):
-    #         os.makedirs(os.path.dirname(logfile))
-    # global_logfile = logfile
-    
-    # if level is None:
-    #     level = config.get('loglevel', logging.DEBUG)
-    # if not isinstance(level, int):
-    #     level = _log_levels_byname.get(str(level), level)
-    # if not isinstance(level, int):
-    #     raise ConfigurationException("Unrecognized loglevel value: "+str(level))
-
-    # if not format:
-    #     format = config.get('logformat', LOG_FORMAT)
-    # frmtr = logging.Formatter(format)
-
-    # global _log_handler
-    # rootlogger = logging.getLogger()
-    # if _log_handler:
-    #     rootlogger.removeHandler(_log_handler)
-    #     if hasattr(_log_handler, 'close'):
-    #         _log_handler.close()
-    #     _log_handler = None
-    # _log_handler = logging.FileHandler(logfile)
-    # _log_handler.setLevel(level)
-    # _log_handler.setFormatter(frmtr)
-    # rootlogger.addHandler(_log_handler)
-    # rootlogger.setLevel(logging.DEBUG-1)
-
-    # # jsonmerge is way too chatty at the DEBUG level
-    # if level >= logging.DEBUG:
-    #     jmlevel = max(level, logging.INFO)
-    #     logging.getLogger("jsonmerge").setLevel(jmlevel)
-
-    # # filelock is one level too chatty
-    # if level >= logging.DEBUG:
-    #     logging.getLogger("filelock").setLevel(level+10)
-
-    # # config can set levels on a per-logname basis
-    # if config.get("loglevelsfor") and isinstance(config.get("loglevelsfor"), Mapping):
-    #     for lognm, level in config.get("loglevelsfor", {}).items():
-    #         if not isinstance(level, int):
-    #             level = _log_levels_byname.get(str(level), level)
-    #         if isinstance(level, int):
-    #             logging.getLogger(lognm).setLevel(level)
-    
-    # if addstderr:
-    #     if not isinstance(addstderr, str):
-    #         addstderr = format
-    #     handler = logging.StreamHandler(sys.stderr)
-    #     handler.setLevel(logging.ERROR)
-    #     handler.setFormatter(logging.Formatter(addstderr))
-    #     rootlogger.addHandler(handler)
-    #     rootlogger.error("FYI: Writing log messages to %s",logfile)
 
 def determine_default_logdir():
     out = os.environ.get('OAR_LOG_DIR', os.path.join(oar_home, 'var', 'logs'))

--- a/python/nistoar/base/logging/__init__.py
+++ b/python/nistoar/base/logging/__init__.py
@@ -1,0 +1,7 @@
+"""
+Common support for logging.
+
+
+
+See also :py:func:`nistoar.base.config.configure_log`.
+"""

--- a/python/nistoar/base/logging/server.py
+++ b/python/nistoar/base/logging/server.py
@@ -20,6 +20,9 @@ from .. import config
 from ..config import ConfigurationException
 
 APP_NAME = "LogServer"
+serverlog = logging.getLogger(APP_NAME)
+def _trace(msg, *args, **kwargs):
+    serverlog.log(config.TRACE, msg, *args, **kwargs)
 
 class LogRecordStreamHandler(socketserver.BaseRequestHandler):
     """
@@ -43,7 +46,7 @@ class LogRecordStreamHandler(socketserver.BaseRequestHandler):
             while len(chunk) < slen:
                 chunk = chunk + self.request.recv(slen - len(chunk))
             obj = self.unPickle(chunk)
-            logging.info("sending message")
+            _trace("sending message")
             record = logging.makeLogRecord(obj)
             self.handleLogRecord(record)
 
@@ -80,7 +83,7 @@ class LogRecordSocketReceiver(socketserver.ThreadingTCPServer):
 
     def serve_forever(self, poll_interval=0.5):
         now = datetime.now().isoformat()
-        logging.getLogger(APP_NAME).info("Starting Log Server at %s", now)
+        serverlog.info("Starting Log Server at %s", now)
         super().serve_forever(poll_interval)
 
 def define_options(progname):
@@ -160,6 +163,7 @@ def main(prog, args, cfg=None):
     cfg.setdefault('logformat', config.SERVER_LOG_FORMAT)
 
     config.configure_logging(cfg)
+    
     pidfile = determine_pidfile(opts.pidfile)
     if opts.stop:
         return stop_server(pidfile)
@@ -170,7 +174,6 @@ def main(prog, args, cfg=None):
     return 0
 
 def stop_server(pidfile):
-    log = logging.getLogger(APP_NAME)
     if not os.path.isfile(pidfile):
         print(f"{APP_NAME}: No server found to be running ({pidfile} not found)",
               file=sys.stderr)

--- a/python/nistoar/base/logging/server.py
+++ b/python/nistoar/base/logging/server.py
@@ -20,9 +20,8 @@ from .. import config
 from ..config import ConfigurationException
 
 APP_NAME = "LogServer"
-serverlog = logging.getLogger(APP_NAME)
 def _trace(msg, *args, **kwargs):
-    serverlog.log(config.TRACE, msg, *args, **kwargs)
+    logging.getLogger(APP_NAME).log(config.TRACE, msg, *args, **kwargs)
 
 class LogRecordStreamHandler(socketserver.BaseRequestHandler):
     """
@@ -73,17 +72,18 @@ class LogRecordSocketReceiver(socketserver.ThreadingTCPServer):
     """
 
     allow_reuse_address = True
+    logname = APP_NAME
 
     def __init__(self,
                  host='localhost',
                  port=logging.handlers.DEFAULT_TCP_LOGGING_PORT,
                  handler=LogRecordStreamHandler):
         socketserver.ThreadingTCPServer.__init__(self, (host, port), handler)
-        self.logname = None
+        self.log = logging.getLogger(self.logname)
 
     def serve_forever(self, poll_interval=0.5):
         now = datetime.now().isoformat()
-        serverlog.info("Starting Log Server at %s", now)
+        self.log.info("Starting Log Server at %s", now)
         super().serve_forever(poll_interval)
 
 def define_options(progname):

--- a/python/nistoar/base/logging/server.py
+++ b/python/nistoar/base/logging/server.py
@@ -157,8 +157,9 @@ def main(prog, args, cfg=None):
     cfg.setdefault('logfile', 'logserver.log')
     if opts.logfile:
         cfg['logfile'] = opts.logfile
+    cfg.setdefault('logformat', config.SERVER_LOG_FORMAT)
 
-    config.configure_log(config=cfg)
+    config.configure_logging(cfg)
     pidfile = determine_pidfile(opts.pidfile)
     if opts.stop:
         return stop_server(pidfile)

--- a/python/nistoar/base/logging/server.py
+++ b/python/nistoar/base/logging/server.py
@@ -1,0 +1,312 @@
+"""
+A Server that can accept and record logging messages from multiple processes.
+
+This implementation is based on the server referenced in the 
+`Python Logging Cookbook <https://docs.python.org/3/howto/logging-cookbook.html#network-logging>` 
+with an implementation 
+`kindly provided by Vinay Sajip <https://gist.github.com/vsajip/4b227eeec43817465ca835ca66f75e2b>` 
+(c. 2020, Red Dove Consultants) via the 
+`BSD-3 License <https://opensource.org/license/bsd-3-clause>`.
+"""
+# See source implementation license at end of this file
+import sys, os, json, logging.handlers, socketserver, struct, pickle
+from argparse import ArgumentParser
+import traceback as tb
+from datetime import datetime
+
+import psutil
+
+from .. import config
+from ..config import ConfigurationException
+
+APP_NAME = "LogServer"
+
+class LogRecordStreamHandler(socketserver.BaseRequestHandler):
+    """
+    Handler for a streaming logging request.
+    This basically logs the record using whatever logging policy is
+    configured locally.
+    """
+
+    def handle(self):
+        """
+        Handle multiple requests - each expected to be a 4-byte length,
+        followed by the LogRecord in pickle format. Logs the record
+        according to whatever policy is configured locally.
+        """
+        while True:
+            chunk = self.request.recv(4)
+            if len(chunk) < 4:
+                break
+            slen = struct.unpack('>L', chunk)[0]
+            chunk = self.request.recv(slen)
+            while len(chunk) < slen:
+                chunk = chunk + self.request.recv(slen - len(chunk))
+            obj = self.unPickle(chunk)
+            logging.info("sending message")
+            record = logging.makeLogRecord(obj)
+            self.handleLogRecord(record)
+
+    def unPickle(self, data):
+        return pickle.loads(data)
+
+    def handleLogRecord(self, record):
+        # if a name is specified, we use the named logger rather than the one
+        # implied by the record.
+        if self.server.logname is not None:
+            name = self.server.logname
+        else:
+            name = record.name
+        logger = logging.getLogger(name)
+        # N.B. EVERY record gets logged. This is because Logger.handle
+        # is normally called AFTER logger-level filtering. If you want
+        # to do filtering, do it at the client end to save wasting
+        # cycles and network bandwidth!
+        logger.handle(record)
+
+class LogRecordSocketReceiver(socketserver.ThreadingTCPServer):
+    """
+    Simple TCP socket-based logging receiver suitable for testing.
+    """
+
+    allow_reuse_address = True
+
+    def __init__(self,
+                 host='localhost',
+                 port=logging.handlers.DEFAULT_TCP_LOGGING_PORT,
+                 handler=LogRecordStreamHandler):
+        socketserver.ThreadingTCPServer.__init__(self, (host, port), handler)
+        self.logname = None
+
+    def serve_forever(self, poll_interval=0.5):
+        now = datetime.now().isoformat()
+        logging.getLogger(APP_NAME).info("Starting Log Server at %s", now)
+        super().serve_forever(poll_interval)
+
+def define_options(progname):
+    """
+    return an ArgumentParser configured with server command line options
+    """
+    description = \
+"""Collect log messages from multiple processes for recording to a
+combined log file."""
+    epilog = None
+
+    parser = ArgumentParser(progname, None, description, epilog)
+
+    parser.add_argument('-c', '--config-file', type=str, metavar='FILE',
+                        dest='cfgfile',
+                        help='load the configuration from FILE')
+    parser.add_argument('-C', '--no-config', action='store_true', 
+                        dest='noconfig', default=False,
+                        help='Do not attempt to load configuration; '
+                             '(requires -p and -l)')
+    parser.add_argument('-N', '--config-name', type=str, metavar='NAME',
+                        dest='cfgname', default='logserver',
+                        help='the name to use to retrieve configuration ' +
+                             'from a configuration server. (Ignored when ' +
+                             '-c is used')
+    parser.add_argument('-p', '--port', type=int, metavar='N', default=None,
+                        dest='port',
+                        help='list for log messages on port N (overriding '
+                             'configuration)')
+    parser.add_argument('-l', '--log-file', type=str, metavar='FILE',
+                        dest='logfile', default=None,
+                        help='use FILE as the output log file (overriding '
+                             'configuration)')
+    parser.add_argument('-P', '--pid-file', type=str, metavar='FILE',
+                        dest='pidfile', default=None,
+                        help='location of pid file that can be used to kill '
+                             'the server; if not specified, a file matching '
+                             'the name of the log but with the .pid extension '
+                             'will be written')
+    parser.add_argument('-k', '--kill-server', action='store_true',
+                        dest='stop',
+                        help='stop a running server using it PID file')
+    parser.add_argument('-T', '--tag', type=str, metavar='ID',
+                        dest='tag', default=None,
+                        help='a label to use to help identify the server '
+                             'process when it comes time to kill it')
+
+    return parser
+
+def main(prog, args, cfg=None):
+    parser = define_options(prog)
+    opts = parser.parse_args(args)
+
+    if not cfg and not opts.noconfig:
+      if opts.cfgfile:
+          try:
+              cfg = config.load_from_file(opts.cfgfile)
+          except Exception as ex:
+              raise ConfigurationException("Failed to read config file, %s: %s" %
+                                           (opts.cfgfile, str(ex))) from ex
+
+      else:
+          # requires env vars OAR_CONFIG_SERVICE, OAR_CONFIG_ENV to be set
+          cfg = config.service.get(opts.cfgname)
+
+      if not cfg and not opts.port:
+          raise ConfigurationException("No configuration available for " +
+                                       opts.cfgname)
+
+    if opts.port:
+        if not cfg:
+            cfg = {}
+        cfg['port'] = opts.port
+    cfg.setdefault('logfile', 'logserver.log')
+    if opts.logfile:
+        cfg['logfile'] = opts.logfile
+
+    config.configure_log(config=cfg)
+    pidfile = determine_pidfile(opts.pidfile)
+    if opts.stop:
+        return stop_server(pidfile)
+    record_pid(pidfile, opts)
+        
+    server = make_server(cfg)
+    server.serve_forever()
+    return 0
+
+def stop_server(pidfile):
+    log = logging.getLogger(APP_NAME)
+    if not os.path.isfile(pidfile):
+        print(f"{APP_NAME}: No server found to be running ({pidfile} not found)",
+              file=sys.stderr)
+        return 0
+
+    try:
+        with open(pidfile) as fd:
+            pidnm = fd.readline().split()
+    except Exception as ex:
+        print(f"{APP_NAME}: {pidfile}: Failed to read pid file: {str(ex)}")
+        return 3
+
+    if not pidnm[0]:
+        print(f"{APP_NAME}: No server found ({pidfile}: empty)", file=sys.stderr)
+
+    pnm = pidnm[1] if len(pidnm) > 1 else None
+    tag = pidnm[2] if len(pidnm) > 2 else None
+    try:
+        p = psutil.Process(int(pidnm[0]))
+        if (pnm and p.cmdline()[0] != pnm) or \
+           (tag and not any(tag in a for a in p.cmdline())):
+            print(f"{APP_NAME}: No server found running (stale pid file?)",
+                  file=sys.stderr)
+            print(f"  {' '.join(pidnm)}", file=sys.stderr)
+            return 0
+        p.kill()
+        p.wait(5)
+    except (ValueError, TypeError) as ex:
+        print(f"{APP_NAME}: Bad PID contents: not a number: {pidnm[0]}",
+              file=sys.stderr)
+        return 3
+    except psutil.NoSuchProcess as ex:
+        print(f"{APP_NAME}: Server not running with pid={pidnm[0]}",
+              file=sys.stderr)
+        return 0
+    except psutil.TimeoutExpired as ex:
+        print(f"{APP_NAME}: Server (pid={pidnm[0]}) not responding",
+              file=sys.stderr)
+        return 1
+    except Exception as ex:
+        print(f"{APP_NAME}: Failed to find/kill server: {str(ex)}",
+              file=sys.stderr)
+        return 4
+    else:
+        try:
+            os.remove(pidfile)
+        except IOError as ex:
+            print(f"{APP_NAME}: Trouble removing pid file: {pidfile}: {str(ex)}")
+
+    return 0
+
+def determine_pidfile(pidfile=None):
+    if not pidfile:
+        pidfile = os.path.splitext(config.global_logfile)[0] + ".pid"
+    elif not os.path.isabs(pidfile):
+        pidfile = os.path.join(config.global_logdir, pidfile)
+    return pidfile
+
+def record_pid(pidfile=None, opts=None):
+    if not pidfile:
+        pidfile = determine_pidfile()
+    pid = os.getpid()
+    try:
+        p = psutil.Process(pid)
+        
+        with open(pidfile, 'w') as fd:
+            fd.write(str(pid))
+            fd.write(' ')
+            fd.write(p.cmdline()[0])
+            if opts.tag:
+                fd.write(' ')
+                fd.write(opts.tag)
+            fd.write('\n')
+    except Exception as ex:
+        log = logging.getLogger(APP_NAME)
+        log.error("Failed to write PID file (%s): %s", pidfile, str(ex))
+        print(f"{APP_NAME}: Failed to write PID file {pidfile}: {str(ex)}")
+
+    return pidfile
+
+def make_server(cfg):
+    """
+    create and return an instance of the loggging server, ready to handle
+    logging messages.
+    """
+    port = cfg.get('port', logging.handlers.DEFAULT_TCP_LOGGING_PORT)
+    return LogRecordSocketReceiver(port=port)
+
+if __name__ == '__main__':
+    prog = APP_NAME
+    args = sys.argv[1:]
+    try:
+        rc = main(prog, args)
+    except KeyboardInterrupt:
+        rc = 2
+        print("Keyboard interrupt", file=sys.stderr)
+    except ConfigurationException as ex:
+        rc = 1
+        print(f"{prog}: {str(ex)}", file=sys.stderr) 
+    except Exception as ex:
+        rc = 4
+        tb.print_exception(ex);
+        print(f"{prog}: {str(ex)}")
+    sys.exit(rc)
+
+
+# The above code was adapted from the logging server provided by Vinay
+# Sajip at https://gist.github.com/vsajip/4b227eeec43817465ca835ca66f75e2b,
+# licensed as follows:
+#
+# Copyright 2002 Red Dove Consultants
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met: 
+# 
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer. 
+# 
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the
+#    distribution. 
+# 
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission. 
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE. 

--- a/python/setup.py
+++ b/python/setup.py
@@ -65,7 +65,7 @@ setup(name='nistoar',
       scripts=[os.path.join("..","scripts",s) for s in 
                ["pdl2resources.py", "ingest-nerdm-res.py",
                 "ingest-field-info.py", "ingest-taxonomy.py",
-                "ingest-uwsgi.py" ]],
+                "ingest-uwsgi.py", "logserver" ]],
       cmdclass={'build_py': build},
       classifiers=[
           'Programming Language :: Python :: 3 :: Only'

--- a/python/tests/nistoar/base/logging/test_server.py
+++ b/python/tests/nistoar/base/logging/test_server.py
@@ -1,0 +1,109 @@
+"""
+test logging server
+"""
+import os, sys, json, logging, subprocess, argparse, pdb, time, tempfile
+import unittest as test
+from pathlib import Path
+from copy import deepcopy
+import logging.config
+
+from nistoar.base.logging import server as logsrvr
+
+tmpdir = tempfile.TemporaryDirectory(prefix="_test_logger.")
+testdir = Path(__file__).parents[0]
+
+server_config = {
+    "logdir": tmpdir.name,
+    "logfile": "test.log",
+    "loglevel": "DEBUG",
+    "port": 9200
+}
+
+def setUpModule():
+    with open(os.path.join(tmpdir.name, "config.json"), 'w') as fd:
+        json.dump(server_config, fd, indent=2)
+
+def tearDownModule():
+    tmpdir.cleanup()
+
+class TestLogServer(test.TestCase):
+
+    def setUp(self):
+        self.logfile = os.path.join(tmpdir.name, server_config['logfile'])
+
+        cmd = "python -m nistoar.base.logging.server -c %s -T testLogServer" % \
+              os.path.join(tmpdir.name, "config.json")
+        self.serverproc = subprocess.Popen(cmd.split())
+        time.sleep(0.2)
+
+        clicfg = {
+            "version": 1,
+            "disable_existing_loggers": True,
+            "formatters": {
+                "default": {
+                    "format": "%(asctime)s %(levelname)-8s %(name)s %(message)s"
+                }
+            },
+            "handlers": {
+                "socket": {
+                    "class": "logging.handlers.SocketHandler",
+                    "host": "localhost",
+                    "port": 9200
+                }
+            },
+            "root": {
+                "level": "INFO",
+                "handlers": ["socket"]
+            }
+        }
+        logging.config.dictConfig(clicfg)
+
+    def tearDown(self):
+        status = self.serverproc.poll() 
+        if status is None or status <= 0:
+            self.serverproc.kill()
+            self.serverproc.wait(5)
+
+        if os.path.isfile(self.logfile):
+            os.remove(self.logfile)
+
+    def test_log(self):
+        with open(self.logfile) as fd:
+            # contains just the log opener record
+            self.assertEqual(len([line for line in fd]), 1)
+            
+        logging.info("msg1")
+        time.sleep(0.1)
+        logging.debug("msg2")
+        try:
+            raise RuntimeError("test exception")
+        except Exception as ex:
+            logging.exception(ex)
+        logging.warning("msg3")
+        time.sleep(0.2)
+
+        with open(self.logfile) as fd:
+            self.assertEqual(len([line for line in fd]), 11)
+
+    def no_test_stop(self):
+        self.assertIsNone(self.serverproc.poll())
+
+        cmd = "python -m nistoar.base.logging.server -c %s -k" % \
+              os.path.join(tmpdir.name, "config.json")
+        kproc = subprocess.Popen(cmd.split())
+        try:
+            kproc.wait(0.5)
+        except Exception:
+            pass
+
+        self.assertIsNotNone(self.serverproc.poll())
+
+                         
+if __name__ == '__main__':
+    test.main()
+
+
+
+
+        
+            

--- a/python/tests/nistoar/base/test_config.py
+++ b/python/tests/nistoar/base/test_config.py
@@ -101,8 +101,19 @@ class TestConfig(test.TestCase):
 class TestLogConfig(test.TestCase):
 
     def resetLogfile(self):
-        if config._log_handler:
-            self.rootlog.removeHandler(config._log_handler)
+        reset = {
+            "version": 1,
+            "disable_existing_loggers": True,
+            "root": {
+                "level": logging.DEBUG,
+                "handlers": []
+            }
+        }
+        logging.config.dictConfig(reset)
+        config.global_logdir = None
+        config.global_logfile = None
+        self.assertEqual(len(logging.getLogger().handlers), 0)
+        
         if self.logfile and os.path.exists(self.logfile):
             os.remove(self.logfile)
         self.logfile = None
@@ -136,7 +147,9 @@ class TestLogConfig(test.TestCase):
         self.assertEqual(config.global_logfile, self.logfile)
 
         self.assertEqual(self.rootlog.getEffectiveLevel(), logging.DEBUG-1)
-        self.assertEqual(config._log_handler.level, logging.DEBUG)
+        self.assertEqual(len(self.rootlog.handlers), 1)
+        self.assertEqual(self.rootlog.handlers[0].level, logging.DEBUG)
+
         self.assertEqual(logging.getLogger("pymongo").getEffectiveLevel(), logging.INFO)
 
         self.rootlog.warning('Oops')
@@ -145,7 +158,70 @@ class TestLogConfig(test.TestCase):
             words = fd.read()
         self.assertIn("Oops", words)
 
+    def test_configure_logging_backcompat(self):
+        logfile = "cfgd.log"
+        cfg = {
+            'logdir': tmpd,
+            'logfile': logfile,
+            'loglevel': 'DEBUG',
+            'loglevelsfor': {
+                'pymongo': 'INFO'
+            }
+        }
 
+        self.logfile = os.path.join(tmpd, logfile)
+        self.assertFalse(os.path.exists(self.logfile))
+
+        config.configure_logging(cfg)
+        self.assertEqual(config.global_logdir, tmpd)
+        self.assertEqual(config.global_logfile, self.logfile)
+
+        self.assertEqual(self.rootlog.getEffectiveLevel(), logging.DEBUG-1)
+        self.assertEqual(len(self.rootlog.handlers), 1)
+        self.assertEqual(self.rootlog.handlers[0].level, logging.DEBUG)
+
+        self.assertEqual(logging.getLogger("pymongo").getEffectiveLevel(), logging.INFO)
+
+        self.rootlog.warning('Oops')
+        self.assertTrue(os.path.exists(self.logfile))
+        with open(self.logfile) as fd:
+            words = fd.read()
+        self.assertIn("Oops", words)
+
+    def test_configure_logging_logserver1(self):
+        rootlog = logging.getLogger()
+        self.assertEqual(len(rootlog.handlers), 0)
+
+        cfg = {
+            'logserver': 'localhost',
+            'loglevel': 'INFO'
+        }
+        config.configure_logging(cfg)
+
+        self.assertEqual(len(rootlog.handlers), 1)
+        self.assertTrue(isinstance(rootlog.handlers[0], logging.handlers.SocketHandler))
+        self.assertEqual(rootlog.handlers[0].level, logging.INFO)
+        self.assertEqual(rootlog.handlers[0].host, 'localhost')
+        self.assertEqual(rootlog.handlers[0].port,
+                         logging.handlers.DEFAULT_TCP_LOGGING_PORT)
+
+        cfg['logfile'] = "goob.log"
+        config.configure_logging(cfg)
+
+        self.assertEqual(len(rootlog.handlers), 2)
+        self.assertTrue(isinstance(rootlog.handlers[0], logging.handlers.SocketHandler))
+        self.assertEqual(rootlog.handlers[0].level, logging.INFO)
+        self.assertEqual(rootlog.handlers[0].host, 'localhost')
+        self.assertEqual(rootlog.handlers[0].port,
+                         logging.handlers.DEFAULT_TCP_LOGGING_PORT)
+        self.assertTrue(isinstance(rootlog.handlers[1], logging.FileHandler))
+
+        config.configure_logging({})
+
+        self.assertEqual(len(rootlog.handlers), 1)
+        self.assertTrue(isinstance(rootlog.handlers[0], logging.FileHandler))
+        self.assertEqual(rootlog.handlers[0].level, logging.DEBUG)
+        
         
     def test_abs(self):
         self.logfile = os.path.join(tmpd, "cfgfile.log")
@@ -155,7 +231,11 @@ class TestLogConfig(test.TestCase):
 
         self.assertFalse(os.path.exists(self.logfile))
         config.configure_log(logfile=self.logfile, config=cfg)
-        self.rootlog.warning('Oops')
+        rootlog = logging.getLogger()
+        self.assertEqual(len(rootlog.handlers), 1)
+        self.assertTrue(isinstance(rootlog.handlers[0], logging.FileHandler))
+        
+        rootlog.warning('Oops')
         self.assertTrue(os.path.exists(self.logfile))
         
 class TestConfigService(test.TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ bagit>=1.6.3,<2.0
 fs>=2.0.21
 jsonpatch
 jsonpath_ng
+psutil
 ejsonschema @ https://github.com/usnistgov/ejsonschema/archive/master.zip
 pynoid @ https://github.com/RayPlante/pynoid/archive/master.zip
 multibag @ https://github.com/usnistgov/multibag-py/archive/0.3.zip

--- a/scripts/logserver
+++ b/scripts/logserver
@@ -1,0 +1,3 @@
+#! /bin/bash
+#
+exec python -m nistoar.base.logging.server "${@}"


### PR DESCRIPTION
This PR adds the module `nistoar.base.logging.server` which provides an implementation of a logging server based on the example given in the [Python Logging Cookbook](https://docs.python.org/3.10/howto/logging-cookbook.html#running-a-logging-socket-listener-in-production).  The `nistoar.base.config` module was also updated to allow a service to send messages to a log server via its logging configuration.  This latter part involved deprecating the module function `configure_log()` with the replacement, `configure_logging()`.  Not only does it add support for the new parameter, `logserver`, but also allows one to configure logging using the standard logging schema defined in standard module `logging.config`; OAR applications can put this configuration into a parameter called `logging`.  

The motivation for this PR is the need to run multiple service worker threads to scale to many simultaneous clients.  Since standard python logging is not multiprocessing-safe, a log server is needed to collect the messages into a single destination log.   