### PR TITLE
Support multiple taxonomies through unified module

### DIFF
--- a/model/taxonomyLocations-by-patt.yml
+++ b/model/taxonomyLocations-by-patt.yml
@@ -1,0 +1,1 @@
+pattern: "^.*[-_]taxonomy.*"

--- a/model/theme-taxonomy-pre1.0.json
+++ b/model/theme-taxonomy-pre1.0.json
@@ -1,8 +1,8 @@
 {
-    "_schema": "https://www.nist.gov/od/dm/simple-taxonomy/v1.0",
-    "@id": "https://www.nist.gov/od/dm/nist-themes/v1.0",
+    "_schema": "https://data.nist.gov/od/dm/simple-taxonomy/v1.0",
+    "@id": "https://data.nist.gov/od/dm/nist-themes/p1.0",
     "title": "The NIST Research Theme Taxonomy",
-    "version": "1.0",
+    "version": "pre1.0",
     "description": "terms for tagging resources with research themes",
     "vocab": [
         {

--- a/model/theme-taxonomy.json
+++ b/model/theme-taxonomy.json
@@ -980,7 +980,7 @@
         {
             "parent": "Information Technology: Software research",
             "term": "Software testing",
-            "Level": 3,
+            "level": 3,
             "since": "2.0"
         },
         {

--- a/python/nistoar/nerdm/taxonomy.py
+++ b/python/nistoar/nerdm/taxonomy.py
@@ -1,5 +1,9 @@
 """
-module for matching terms from the NIST research topic taxonomy
+module for matching terms from the NIST research topic taxonomy.  This is deprecated 
+by the :py:mod:`nistoar.taxonomy` module.  
+
+See the use of the deprecated :py:class:`ResearchTopicsTaxonomy` in 
+:py:class:`nistoar.nerdm.convert.pod.PODds2Res` (which is also deprecated).  
 """
 import os, re, json
 from collections import OrderedDict

--- a/python/nistoar/taxonomy/__init__.py
+++ b/python/nistoar/taxonomy/__init__.py
@@ -1,5 +1,39 @@
 """
 classes and functions that assist with using terms from taxonomies
+
+This module provides implementations for finding and accessing multiple taxonomies.  In 
+particular, it provides the facilities to load a taxonomy's definitions and use that 
+information to match terms and even test broader and narrower relationships.  
+
+The module is designed to handle taxonomy definitions from multiple sources and using 
+multiple formats and schemas.  (At this writing, only the OAR-specific "simple" schema
+loaded from files is supported.)
+
+The module is build around two key classes: :py:class:`~nistoar.taxonomy.base.Taxonomy` and 
+:py:class:`~nistoar.taxonomy.base.TaxonomyCache`.  The latter is used to discover and register 
+all taxonomies available to the system.  From that class, one can open up a taxonomy as a 
+:py:class:`~nistoar.taxonomy.base.Taxonomy` instance given its identifier string.  With a 
+:py:class:`~nistoar.taxonomy.base.Taxonomy` instance in hand, one can access specific terms 
+in the taxonomy either via its identifier or its prefered label.  
+
+The simplest way to initiate a :py:class:`~nistoar.taxonomy.base.TaxonomyCache` is via the 
+function, :py:func:`nistoar.taxonomy.open_taxonomy_cache`: 
+
+.. code-block::
+   :caption: Example use of the taxonomy module
+
+   import os
+   from pathlib import Path
+   from nistoar import taxonomy
+   from nistoar.midas.dap.service.mds3 import NIST_THEMES  # the NIST research topics taxonomy URI
+
+   taxdir = Path(os.environ['OAR_HOME']) / "etc" / "schemas"
+   cache = taxonomy.open_taxonomy_cache(taxdir)
+   taxon = cache.open_taxonomy(NIST_THEMES)
+   biosci = taxon.match_label("Bioscience")
+
+See the :py:class:`Taxonomy documentation <nistoar.taxonomy.base.Taxonomy>` for more on what 
+you can do with a taxonomy.
 """
 from .base import *
 from .simple import SimpleTaxonomy

--- a/python/nistoar/taxonomy/__init__.py
+++ b/python/nistoar/taxonomy/__init__.py
@@ -7,10 +7,25 @@ from .cache.files import FileTaxonomyCache
 
 OAR_TAXON_FILE_PATTERN = r'.*taxonomy.*'
 
-def open_taxonomy_cache(taxondir: str, log: Logger=None):
+def open_taxonomy_cache(taxondir: str, pattern: str=None, log: Logger=None):
     """
-    return a :py:class:`~nistoar.pdr.utils.taxonomy.cache.files.FileTaxonomyCache` instance
-    for accessing taxonomy definitions.
+    return a :py:class:`~nistoar.pdr.utils.taxonomy.TaxonomyCache` instance which provides
+    access to taxonomies known to the OAR system.  
+
+    This implementation returns a 
+    :py:class:`~nistoar.pdr.utils.taxonomy.cache.files.FileTaxonomyCache` instance,
+    specifically.  When initializing, it is tolerant about problems with taxonomies (e.g. 
+    missing taxonomy file, errors while parsing, etc.): it simply skips over problem 
+    taxonomy files and its definitions will be considered "unknown".  Provide a Logger
+    to record warnings about such errors.
+
+    :param str|Path taxondir: the path to the directory containing the taxonomy files
+    :param str       pattern: a Python regular expression for matching taxonomy file names 
+                              in the directory; only files matching this pattern will be 
+                              loaded into the cache.  If None (default), this function will 
+                              rely on the presense of a taxonomyLocations.yml (or .json) 
+                              file for finding the taxonomies
+    :param Logger        log: a Logger to use to warn about unreadable taxonomy files.
     """
-    return FileTaxonomyCache(taxondir, OAR_TAXON_FILE_PATTERN, log)
+    return FileTaxonomyCache(taxondir, pattern, log)
     

--- a/python/nistoar/taxonomy/__init__.py
+++ b/python/nistoar/taxonomy/__init__.py
@@ -1,0 +1,16 @@
+"""
+classes and functions that assist with using terms from taxonomies
+"""
+from .base import *
+from .simple import SimpleTaxonomy
+from .cache.files import FileTaxonomyCache
+
+OAR_TAXON_FILE_PATTERN = r'.*-taxonomy.*'
+
+def open_taxonomy_cache(taxondir: str, log: Logger=None):
+    """
+    return a :py:class:`~nistoar.pdr.utils.taxonomy.cache.files.FileTaxonomyCache` instance
+    for accessing taxonomy definitions.
+    """
+    return FileTaxonomyCache(taxondir, OAR_TAXON_FILE_PATTERN, log)
+    

--- a/python/nistoar/taxonomy/__init__.py
+++ b/python/nistoar/taxonomy/__init__.py
@@ -5,7 +5,7 @@ from .base import *
 from .simple import SimpleTaxonomy
 from .cache.files import FileTaxonomyCache
 
-OAR_TAXON_FILE_PATTERN = r'.*-taxonomy.*'
+OAR_TAXON_FILE_PATTERN = r'.*taxonomy.*'
 
 def open_taxonomy_cache(taxondir: str, log: Logger=None):
     """

--- a/python/nistoar/taxonomy/base.py
+++ b/python/nistoar/taxonomy/base.py
@@ -1,0 +1,228 @@
+"""
+Base classes and utility functions for 
+:py:mod:`supporting taxonomies <nistoar.pdr.utils.taxonomy>`.
+"""
+import json, re, os
+from pathlib import Path
+from abc import ABC, abstractmethod
+from logging import Logger
+from copy import deepcopy
+from typing import Iterator, Mapping
+
+import yaml
+
+class Taxonomy(ABC):
+    """
+    a container of terms defined in a taxonomy
+    """
+    def __init__(self, id):
+        self._id = id
+
+    @property 
+    def id(self) -> str:
+        """
+        return the identifier for this taxonomy
+        """
+        return self._id
+
+    @abstractmethod
+    def count(self) -> int:
+        """
+        return the number of terms in this taxonomy
+        """
+        raise NotImplemented()
+
+    @abstractmethod
+    def about(self) -> Mapping:
+        """
+        returns a dictionary of information about a taxonomy as a whole
+        """
+        raise NotImplemented()
+
+    @abstractmethod
+    def about_term(self, label: str) -> Mapping:
+        """
+        returns a dictionary of information about a term given its prefered label
+        """
+        raise NotImplemented()
+
+    @abstractmethod
+    def get(self, termid: str) -> Mapping:
+        """
+        returns a dictionary of information about a term given its URI identifier.  The 
+        termid can either be the absolute, globally-unique ID or one relative to this 
+        taxonomy's identifier.  
+        """
+        raise NotImplemented()
+
+    @abstractmethod
+    def terms(self) -> Iterator[Mapping]:
+        """
+        iterate through all of the terms in this taxonomy, returning each term description
+        as a dictionary (as in like from :py:meth:`get`)
+        """
+        raise NotImplemented()
+
+    def contains(self, labelorid: str) -> bool:
+        """
+        return True if the given term identifier or label are defined in this taxonomy
+        """
+        if self._bylabel.get(labelorid):
+            return True
+        if labelorid.startswith(self.id):
+            labelorid = labelorid[len(self.id):]
+        return bool(self._byid.get(labelorid))
+
+    @abstractmethod
+    def compare_meaning(self, term1: Mapping, term2: Mapping) -> int:
+        """
+        return -1, 0, or +1, depending on whether term1 broader, equivalent, or narrower in 
+        meaning, respectively, than term2, based on the relationships defined in this taxonomy.
+        None is returned if the terms are disjoint--i.e., they have no relationships between 
+        them.
+
+        :param dict term1:  a term known to this taxonomy, given as a dictionary like that 
+                            returned by :py:meth:`get`.
+        :param dict term2:  a term known to this taxonomy, given as a dictionary like that 
+                            returned by :py:meth:`get`.
+        :raise ValueError:  if ``term1`` or ``term2`` is unknown to this taxonomy.
+        """
+        raise NotImplemented()
+
+    def is_broader_than(self, term1: Mapping, term2: Mapping) -> bool:
+        """
+        return True if term1 is a more broad term than term2, based on the relationships 
+        defined in this taxonomy.  False is returned if either term is not known to this 
+        taxonomy.
+
+        :param dict term1:  a term known to this taxonomy, given as a dictionary like that 
+                            returned by :py:meth:`get`.
+        :param dict term2:  a term known to this taxonomy, given as a dictionary like that 
+                            returned by :py:meth:`get`.
+        """
+        try:
+            diff = self.compare_meaning(term1, term2)
+            return diff is not None and diff < 0
+        except ValueError:
+            return False
+
+    def equivalent(self, term1, term2):
+        """
+        return True if the two given terms can be considered equivalent in meaning, based on 
+        relationships given in this taxonomy.  The two terms need not have the same identifier.
+
+        :param dict term1:  a term known to this taxonomy, given as a dictionary like that 
+                            returned by :py:meth:`get`.
+        :param dict term2:  a term known to this taxonomy, given as a dictionary like that 
+                            returned by :py:meth:`get`.
+        """
+        try:
+            diff = self.compare_meaning(term1, term2)
+            return diff is not None and diff == 0
+        except ValueError:
+            return False
+
+    def is_narrower_than_or_equiv(self, term1, term2):
+        """
+        return True if term1 either equivalent to term2 or is a more narrow term than term2, 
+        based on the relationships defined in this taxonomy.  False is returned if either term 
+        is not known to this taxonomy.
+
+        :param dict term1:  a term known to this taxonomy, given as a dictionary like that 
+                            returned by :py:meth:`get`.
+        :param dict term2:  a term known to this taxonomy, given as a dictionary like that 
+                            returned by :py:meth:`get`.        
+        """
+        try:
+            diff = self.compare_meaning(term1, term2)
+            return diff is not None and diff >= 0
+        except ValueError:
+            return False
+
+class TaxonomyCache(ABC):
+    """
+    a class that manages access to taxonomy definitions.
+
+    A cache has access to number of taxonomy definitions.  Creating an instance will typically
+    load metadata for the taxonomies into memory to allow quick lookup and loading the definitions 
+    from their sources.  
+    """
+
+    def __init__(self, log: Logger=None):
+        self.log = log
+
+    @abstractmethod
+    def load_taxonomy(self, id) -> Taxonomy:
+        """
+        return a Taxonomy object with access to the terms in the taxonomy with the given 
+        identifier
+
+        :param str id:  the identifier for the taxonomy (which should include the version 
+                        component, if applicable)
+        :return:  the taxonomy with all its terms accessible
+        """
+        raise NotImplemented()
+
+    @abstractmethod
+    def about(self, id) -> Mapping:
+        """
+        return a small dictionary describing the taxonomy with the given identifier, or None
+        if the identifier is not recognized
+        """
+        raise NotImplemented()
+
+    @abstractmethod
+    def count(self) -> int:
+        """
+        return the total number of taxonomies available
+        """
+        return 0
+
+    @abstractmethod
+    def ids(self) -> Iterator[str]:
+        """
+        return an iderator of the identifiers for the taxonomies available via this cache
+        """
+        raise NotImplemented()
+
+    @abstractmethod
+    def reload(self, **kwargs):
+        """
+        reload the taxonomy metadata from the cache's source
+        """
+        raise NotImplemented()
+
+def _load_file(path, filetype:str="data") -> Mapping:
+    """
+    read a data file as either JSON or YAML (depending on the extension) and return 
+    its contents as a dictionary.  Return None if it can't be read
+
+    :param str      path:  the full path to the file to be read
+    :param Logger errlog:  the Logger to send a warning message to if the file can't be read
+    :param str  filetype:  a string to use in warning message indicating the type of file 
+                           to be read.
+    :raises IOError:  if the file cannot be read for some reason, including an unsupported 
+                      format (as implied by its file extension)
+    :raises ValueError:  if the content of the file cannot be parsed for syntactic reasons
+    """
+    path = Path(path)
+    try:
+        if path.suffix == ".json":
+            with open(path) as fd:
+                data = json.load(fd)
+        elif path.suffix == ".yml" or path.suffix == ".yaml":
+            with open(path) as fd:
+                data = yaml.safe_load(fd)
+        else:
+            raise RuntimeError("unsupported file format")
+
+        return data
+
+    except (json.JSONDecodeError, yaml.YAMLError) as ex:
+        raise ValueError("%s: Unable to parse %s file: %s" %
+                         (str(path), filetype, str(ex)))  from ex
+    except (IOError, RuntimeError) as ex:
+        raise IOError("%s: Failed to read %s file: %s" %
+                      (str(path), filetype, str(ex)))    from ex
+
+        

--- a/python/nistoar/taxonomy/base.py
+++ b/python/nistoar/taxonomy/base.py
@@ -40,18 +40,20 @@ class Taxonomy(ABC):
         raise NotImplemented()
 
     @abstractmethod
-    def about_term(self, label: str) -> Mapping:
+    def match_label(self, label: str) -> Mapping:
         """
-        returns a dictionary of information about a term given its prefered label
+        returns the definition of term in this taxonomy given its given its prefered label
+        :rtype: dict
         """
         raise NotImplemented()
 
     @abstractmethod
     def get(self, termid: str) -> Mapping:
         """
-        returns a dictionary of information about a term given its URI identifier.  The 
+        returns the definition of term in this taxonomy given its URI identifier.  The 
         termid can either be the absolute, globally-unique ID or one relative to this 
         taxonomy's identifier.  
+        :rtype: dict
         """
         raise NotImplemented()
 

--- a/python/nistoar/taxonomy/cache/__init__.py
+++ b/python/nistoar/taxonomy/cache/__init__.py
@@ -1,0 +1,3 @@
+"""
+Implementation of the :py:class:`~nistoar.taxonomy.base.TaxonomyCache` class
+"""

--- a/python/nistoar/taxonomy/cache/files.py
+++ b/python/nistoar/taxonomy/cache/files.py
@@ -62,7 +62,7 @@ class FileTaxonomyCache(TaxonomyCache):
               (str) optional. the date the taxonomy was released
        
     """
-    LOCATION_FILE_BASE = "taxonomyLocation"
+    LOCATION_FILE_BASE = "taxonomyLocations"
 
     def __init__(self, source: str, pattern: str=None, log: Logger=None):
         """

--- a/python/nistoar/taxonomy/cache/files.py
+++ b/python/nistoar/taxonomy/cache/files.py
@@ -1,0 +1,346 @@
+"""
+An implementation of the :py:class:`~nistoar.pdr.utils.TaxonomyCache` in which taxonomy 
+definitions are stored in files.  
+
+In this implementation, taxonomy definition files are discovered either by scanning a 
+directory for files with a given pattern or by reading in a schema location file 
+(``taxonomyLocation.yml`` or ``taxonomyLocation.json``).  
+
+By design, multiple taxonomy definition schemes/formats are supported.  (At the moment,
+only the "simple" scheme is supported.)
+"""
+import re, os, json
+from logging import Logger
+from typing import Iterator, Mapping
+from pathlib import Path
+from copy import deepcopy
+
+import yaml
+
+from ..base import TaxonomyCache, Taxonomy, _load_file
+from ..simple import SimpleTaxonomy
+
+class FileTaxonomyCache(TaxonomyCache):
+    """
+    a class that manages access to taxonomy definitions stored in files.
+
+    In this implementation, a cache is a set of locations of taxonomy definition files on 
+    disk.  The cache is initialized either by scanning a directory for files with a given 
+    pattern or by loading a schema locaiton file.  
+
+    A taxonomy location file can be encoded in JSON or YAML format, but the schema is the 
+    same, where the following properties are supported:
+
+    ``baseDirectory``
+         a directory path for which all taxonomy location paths are relative to (see 
+         ``taxonomy.location`` below).  If given relative as a relative path, it will be 
+         interpreted as relative to the directory where this location file is found.
+    ``pattern``
+         a Python regular expression used to identify taxonomy files in the base directory.
+         When provided and ``taxonomy`` is not provided, the base directory will be scanned 
+         for taxonomy definition files.  
+    ``include``
+         a list of file or directory paths to consult for additional taxonomies.  If the path
+         points to a file, it will be interpreted as a taxonomy location file.  If the path 
+         is a directory, it will be scanned using the file pattern given by ``pattern``.
+    ``taxonomy``
+         a list of taxonomy file summaries to be included in the cache.  Each element summarizes
+         a txonomy and where it can be found using the following sub-properties:
+
+         ``location``
+              (str) required. The path to the file defining the taxonomy.  If not absolute,
+              it should be relative to the base directory.
+         ``id``
+              (str) required. the unique identifier for the taxonomy (usually a URI)
+         ``version``
+              (str) optional. the version of the taxonomy
+         ``title``
+              (str) optional. a title for the taxonomy
+         ``description``
+              (str) optional. a brief description of the taxonomy's use and purpose
+         ``released``
+              (str) optional. the date the taxonomy was released
+       
+    """
+    LOCATION_FILE_BASE = "taxonomyLocation"
+
+    def __init__(self, source: str, pattern: str=None, log: Logger=None):
+        """
+        initialize the cache with taxonomies found in a source location
+
+        :param str  source:  a path to a file or a directory.  If it is a directory and 
+                             the ``pattern`` argument is not provided, this class will 
+                             look for a ``taxonomyLocation.yml`` or ``taxonomyLocation.json``
+                             file which will be used to load the locations and metadata for 
+                             taxonomies in the cache.  If one does not exist, it will use 
+                             ``pattern`` to taxonomies from files in the directory.  If the 
+                             value points to a file, it will be taken as a location file. 
+        :param str pattern:  a regular expression pattern for identifying taxonomy files in the 
+                             ``source`` directory.  If provided, the presence of a taxonomy 
+                             location file is ignored.  This pattern is ignored if ``source`` 
+                             does not point to a directory.
+        """
+        super(FileTaxonomyCache, self).__init__(log)
+        self.src = Path(source)
+        self.patt = pattern
+        self._tx = None
+        self.reload()
+
+    def about(self, id) -> Mapping:
+        try:
+            return deepcopy(self._tx[id])
+        except KeyError:
+            return None
+
+    def is_known(self, id) -> bool:
+        return bool(self._tx[id])
+
+    def count(self) -> int:
+        return len(self._tx)
+
+    def ids(self) -> Iterator[str]:
+        return self._tx.keys()
+
+    def load_taxonomy(self, id) -> Taxonomy:
+        about = self.about(id)
+        if not about:
+            return None
+        return load_taxonomy(about['location'])
+
+    def reload(self, **kwargs):
+        """
+        reload the taxonomy metadata from the cache's source
+        """
+        self._tx = {}
+        if self.src.is_dir():
+            if self.patt:
+                patt = re.compile(self.patt)
+                tfiles = [self.src/f for f in os.listdir(self.src) if patt.search(f)]
+                self._tx = self._load_from_file_scans(tfiles)
+            else:
+                locf = self.src/(self.LOCATION_FILE_BASE+".yml")
+                if not locf.is_file():
+                    locf = self.src/(self.LOCATION_FILE_BASE+".json")
+                if locf.is_file():
+                    self._tx = self._load_locations_from_file(locf)
+
+        else:
+            self._tx = self._load_locations_from_file(self.src)
+
+    def count(self):
+        return len(self._tx)
+
+    def _load_from_file_scans(self, tfiles, out=None, basedir=None):
+        if out is None:
+            out = {}
+        for f in tfiles:
+            tax = self._scan_tax_file(f, basedir)
+            if tax:
+                out[tax['id']] = tax
+        return out
+    
+    def _warn(self, message, *args):
+        if self.log:
+            self.log.warning(message, *args)
+
+    def _scan_tax_file(self, tfile, basedir=None):
+        if isinstance(tfile, str):
+            tfile = Path(tfile)
+        if not tfile.is_absolute():
+            tfile = Path(basedir) / tfile
+        if not tfile.is_file():
+            return None
+
+        try:
+            about = summarize(tfile)
+            if not about:
+                self._warn("%s: no taxonomy info loaded; skipping.", str(locfile))
+                return None
+            
+            about['location'] = str(tfile)
+            return about
+        except (IOError, ValueError) as ex:
+            self._warn(str(ex))
+            return None
+        except Exception as ex:
+            if self.log:
+                log.exception(ex)
+            raise
+
+    def _load_locations_from_file(self, locfile, out=None, visitedfiles=[]):
+        data = {}
+        try: 
+            data = _load_file(locfile, "taxonomy location")
+        except (IOError, ValueError) as ex:
+            self._warn(str(ex))
+            return None
+        except Exception as ex:
+            if self.log:
+                log.exception(ex)
+            raise
+        
+        if not data:
+            self._warn("%s: No taxonomy locations found", str(locfile))
+            return None
+
+        visitedfiles.append(str(locfile))  # prevents include loops
+
+        basedir = data.get('baseDirectory')
+        if not basedir:
+            basedir = locfile.parents[0]
+
+        if out is None:
+            out = {}
+        if data.get('taxonomy'):
+            if not isinstance(data['taxonomy'], list):
+                self._warn("%s: location file format error: taxonomy: not a list", str(tfile))
+                return None
+
+            for tax in data['taxonomy']:
+                if not tax.get('location') or not isinstance(tax['location'], str) or \
+                   not tax.get('id') or not isinstance(tax['id'], str):
+                    continue
+                if not os.path.isabs(tax['location']):
+                    tax['location'] = os.path.join(basedir, tax['location'])
+                out[tax['id']] = tax
+
+        elif data.get('pattern'):
+            patt = re.compile(data['pattern'])
+            tfiles = [basedir/f for f in os.listdir(basedir) if patt.search(f)]
+            self._load_from_file_scans(tfiles, out, basedir)
+
+        if data.get('include'):
+            if not isinstance(data['taxonomy'], list):
+                _warn("%s: location file format error: include: not a list", str(tfile))
+            else:
+                basedir = data.get('baseDirectory')
+                if not basedir:
+                    basedir = locfile.parents[0]
+                for inclloc in data.get('include'):
+                    inclloc = basedir / Path(inclloc)
+                    if str(inclloc) in visitedfiles:
+                        continue
+                    if inclloc.is_file():
+                        self._load_locations_from_file(inclloc, out, visitedfiles)
+                    elif inclloc.is_dir():
+                        visitedfiles.append(inclloc)
+                        tfiles = [inclloc/f for f in os.listdir(inclloc) if patt.search(f)]
+                        self._load_from_file_scans(tfiles, out, inclloc)
+
+        return out
+
+    def export_locations(self, dest, format=None, basedir=None):
+        """
+        export the location information into a taxonomy location file.
+
+        The file will comply with the schema 
+        :py:class:`described in this class <FileTaxonomyCache>`.
+
+        :param str|Path dest:  the path to the destination.  If the path points to an
+                               existing directory, it will be written to a file with 
+                               the standard name, `taxonomyLocations.`*fmt*, where *fmt*
+                               corresponds to a supported format designated by the 
+                               ``format`` argument.  Otherwise, it will be interpreted as 
+                               the output file.  In either case, if the file exists, it 
+                               will be overwritten.
+        :param str    format:  the label indicating the desired format to write the file in.
+                               Supported labels are "json" and "yaml".  If not provided and 
+                               ``dest`` points to a destination file, then the format will
+                               be inferred by the file's extension (where ".yml" is also 
+                               recognized); if the destination file is not specified the 
+                               format defaults to "yaml".  If ``format`` is provided and 
+                               ``dest`` refers to a file, the extension will be ignored.
+        :param str|Path|bool|None basedir:  if a str or Path, interpret it as a directory to set 
+                               as the base directory for taxonomy file locations; all 
+                               locations for taxonomy files in this cache under that path 
+                               will be rewritten to be relative to it.  If True, the base 
+                               directory will be set to the directory implied by ``dest``.  
+                               If False, the base directory is not set, and all locations 
+                               will written as absolute paths.  If None (default), the 
+                               base directory will not be set, but the locations will made 
+                               relative to the base directory implied by ``dest``.  
+                               A value of True or False makes the location file more portable, 
+                               but a value of None makes the whole directory more portable.  
+        """
+        if not dest:
+            dest = self.src
+        else:
+            dest = Path(dest)
+
+        if not format:
+            format = dest.suffix.lstrip('.') if not dest.is_dir() else None
+        if not format or format == "yaml":
+            format = "yml"
+        if format not in "json yml".split():
+            raise ValueError("export_locations(): format not recognized: "+format)
+        if dest.is_dir():
+            dest = dest / f"taxonomyLocations.{format}"
+
+        out = {}
+        if basedir is True:
+            out['baseDirectory'] = str(dest.parents[0])
+            basedir = dest.parents[0]
+        elif basedir:
+            out['baseDirectory'] = str(basedir)
+        elif basedir is None:
+            basedir = dest.parents[0]
+
+        taxlist = []
+        for tax in self._tx.values():
+            taxlist.append(deepcopy(tax))
+            if basedir and Path(tax['location']).is_relative_to(basedir):
+                taxlist[-1]['location'] = str(Path(tax['location']).relative_to(basedir))
+        out['taxonomy'] = taxlist
+
+        with open(dest, 'w') as fd:
+            if format == "json":
+                json.dump(out, fd, indent=2)
+            else:
+                yaml.dump(out, fd, indent=2, default_flow_style=False, sort_keys=False)
+        
+
+_taxon_parsers = {
+    "https://data.nist.gov/od/dm/simple-taxonomy/v1.0": SimpleTaxonomy._from_content
+}
+def load_taxonomy(taxon_file, incl_depr: bool=False) -> Taxonomy:
+    """
+    return an Taxonomy instance for the definitions contained in a given file
+
+    :param str|Path taxon_file:  the path to the file to read
+    :param bool      incl_depr:  if True, include definitions of deprecated terms
+    :raise IOError:   if the the file cannot be read for some reason, including because 
+                      it doesn't exist or has an unrecognized format (based on its extension).
+    :raise ValueEror: if the contents cannot be parsed
+    """
+    content = _load_file(taxon_file, "taxonomy definition")    # may raise exception
+    
+    if not content.get('_schema'):
+        raise ValueError("Taxonomy definition schema (_schema) not specified")
+    if content['_schema'] not in _summary_parsers:
+        raise ValueError("Unrecognized taxonomy definition schema: "+str(data['schema']))
+
+    return _taxon_parsers[content['_schema']](content)
+                        
+_summary_parsers = {
+    "https://data.nist.gov/od/dm/simple-taxonomy/v1.0": SimpleTaxonomy._summary_from
+}
+def summarize(taxon_file):
+    """
+    return summary information about the contents of a taxonomy file for storing into
+    a TaxonomyCache
+
+    :param str|Path taxon_file:  the path to the file to read
+    :raise IOError:   if the the file cannot be read for some reason, including because 
+                      it doesn't exist or has an unrecognized format (based on its extension).
+    :raise ValueEror: if the contents cannot be parsed
+    """
+    content = _load_file(taxon_file, "taxonomy definition")   # may raise exception
+    
+    if not content.get('_schema'):
+        raise ValueError("Taxonomy definition schema (_schema) not specified")
+    if content['_schema'] not in _summary_parsers:
+        raise ValueError("Unrecognized taxonomy definition schema: "+str(content['_schema']))
+    return _summary_parsers[content['_schema']](content)
+            
+            
+        

--- a/python/nistoar/taxonomy/cache/files.py
+++ b/python/nistoar/taxonomy/cache/files.py
@@ -82,6 +82,8 @@ class FileTaxonomyCache(TaxonomyCache):
         """
         super(FileTaxonomyCache, self).__init__(log)
         self.src = Path(source)
+        if not self.src.exists():
+            raise ValueError(f"{str(self.src)}: file or directory not found")
         self.patt = pattern
         self._tx = None
         self.reload()
@@ -173,7 +175,7 @@ class FileTaxonomyCache(TaxonomyCache):
             data = _load_file(locfile, "taxonomy location")
         except (IOError, ValueError) as ex:
             self._warn(str(ex))
-            return None
+            raise
         except Exception as ex:
             if self.log:
                 log.exception(ex)
@@ -187,7 +189,11 @@ class FileTaxonomyCache(TaxonomyCache):
 
         basedir = data.get('baseDirectory')
         if not basedir:
-            basedir = locfile.parents[0]
+            basedir = locfile.parents[0].resolve()
+        else:
+            basedir = Path(basedir)
+            if not basedir.is_absolute():
+                basedir = locfile.parents[0] / basedir
 
         if out is None:
             out = {}

--- a/python/nistoar/taxonomy/simple.py
+++ b/python/nistoar/taxonomy/simple.py
@@ -109,13 +109,13 @@ class SimpleTaxonomy(Taxonomy):
     def about(self) -> Mapping:
         return deepcopy(self._meta)
 
-    def about_term(self, label: str) -> Mapping:
-        return self._bylabel.get(label)
-
     def get(self, termid: str) -> Mapping:
         if termid.startswith(self.id):
             termid = termid[len(self.id):]
         return self._byid.get(termid)
+
+    def match_label(self, label: str) -> Mapping:
+        return self._bylabel.get(label)
 
     def terms(self) -> Iterator[Mapping]:
         return self._byid.values()

--- a/python/nistoar/taxonomy/simple.py
+++ b/python/nistoar/taxonomy/simple.py
@@ -1,0 +1,141 @@
+"""
+Support for taxonomies defined using the OAR-internal "simple" schema/format
+"""
+from copy import deepcopy
+from typing import Iterator, Mapping, NewType
+from urllib.parse import quote as urlquote
+
+from .base import Taxonomy, _load_file
+
+# forward declaration
+SimpleTaxonomy = NewType("SimpleTaxonomy", object)
+
+class SimpleTaxonomy(Taxonomy):
+    """
+    a taxonomy that conforms to the simple taxonomy definition file.  
+
+    This format is optimized for use with topic taxonomies used in NERDm records
+    """
+    SCHEMA_URI = "https://data.nist.gov/od/dm/simple-taxonomy/v1.0"
+
+    @classmethod
+    def from_file(cls, tfile, incl_depr: bool=False) -> SimpleTaxonomy:
+        """
+        return a SimpleTaxonomy instance read in from a simple taxonomy file
+
+        :raise IOError:   if the the file cannot be read for some reason, including because 
+                          it doesn't exist or has an unrecognized format (based on its extension).
+        :raise ValueEror: if the contents cannot be parsed
+        """
+        content = _load_file(tfile, "taxonomy definition")   # may raise exception
+        return cls._from_content(content, incl_depr)
+
+    @classmethod
+    def _from_content(cls, content, incl_depr=False):
+        return cls(cls._parse_content(content), incl_depr)
+
+    @classmethod
+    def _parse_content(cls, content) -> Mapping:
+
+        if not content.get("@id"):
+            raise ValueError(f"{tfile}: Missing taxonomy identifier (@id)")
+        content['id'] = content['@id']
+        del content['@id']
+
+        if not content.get('_schema'):
+            content['_schema'] = cls.SCHEMA_URI
+        content['schema'] = content['_schema']
+        del content['_schema']
+
+        return content
+
+    @classmethod
+    def _summary_from(cls, content: Mapping) -> Mapping:
+        content = cls._parse_content(content)
+        del content['vocab']
+        return content
+
+    def __init__(self, taxdata: Mapping, incl_depr: bool=False):
+        """
+        create an instance from the given taxonomy data.  Normally, this constructor is not 
+        called directly; rather, :py:meth:`from_file` should be called.  
+        """
+        if not taxdata.get('id'):
+            raise ValueError("Missing required property: id")
+        super(SimpleTaxonomy, self).__init__(taxdata['id'])
+
+        vocab = taxdata.get('vocab', [])
+        if taxdata.get('vocab'):
+            del taxdata['vocab']
+        self._meta = taxdata
+        idsansver = self.id.rsplit('/', 1)[0]
+
+        self._bylabel = {}
+        self._byid = {}
+
+        def labelfor(term):
+            out = ''
+            if term.get('parent'):
+                out = term['parent'] + ": "
+            return out + term['term']
+        def label2idfrag(label):
+            return '#' + urlquote(label)
+            
+        for term in vocab:
+            if not term.get('term'):
+                continue
+            if not term.get('label'):
+                term['label'] = labelfor(term)
+
+            if not term.get('id'):
+                frag = label2idfrag(term['label'])
+                term['id'] = self.id + frag
+
+            if term.get('deprecatedSince'):
+                # this is a deprecated term
+                if incl_depr and term.get('lastSupported'):
+                    # include it, but make sure we get the ID right
+                    term['id'] = f"{idsansver}/v{term['lastSupported']}{term.get['id']}"
+                else:
+                    # skipping deprecated terms
+                    continue
+                
+            self._byid[frag] = term
+            self._bylabel[term['label']] = term
+
+    def count(self) -> int:
+        return len(self._byid)
+
+    def about(self) -> Mapping:
+        return deepcopy(self._meta)
+
+    def about_term(self, label: str) -> Mapping:
+        return self._bylabel.get(label)
+
+    def get(self, termid: str) -> Mapping:
+        if termid.startswith(self.id):
+            termid = termid[len(self.id):]
+        return self._byid.get(termid)
+
+    def terms(self) -> Iterator[Mapping]:
+        return self._byid.values()
+
+    def compare_meaning(self, term1: Mapping, term2: Mapping) -> int:
+        if not self.contains(term1['id']):
+            raise ValueError(f"term not known ({term1['label']})")
+        if not self.contains(term2['id']):
+            raise ValueError(f"term not known ({term2['label']})")
+
+        try:
+            if term1['id'] == term2['id'] or term1['label'] == term2['label']:
+                return 0
+            elif term2['label'].startswith(term1['label']+':'):
+                return -1
+            elif term1['label'].startswith(term2['label']+':'):
+                return 1
+        except KeyError:
+            pass
+
+        # the terms are disjoint or one is ill-formed
+        return None
+

--- a/python/nistoar/taxonomy/version.py
+++ b/python/nistoar/taxonomy/version.py
@@ -1,0 +1,6 @@
+"""
+An identification of the subsystem version.  Note that this module file gets 
+(over-) written by the build process.  
+"""
+
+__version__ = "1.0.0rc1-465-gfb56bcc"

--- a/python/nistoar/taxonomy/version.py
+++ b/python/nistoar/taxonomy/version.py
@@ -1,6 +1,0 @@
-"""
-An identification of the subsystem version.  Note that this module file gets 
-(over-) written by the build process.  
-"""
-
-__version__ = "1.0.0rc1-465-gfb56bcc"

--- a/python/tests/nistoar/nerdm/convert/test_pod.py
+++ b/python/tests/nistoar/nerdm/convert/test_pod.py
@@ -85,14 +85,14 @@ class TestPODds2Res(unittest.TestCase):
 
         self.assertIn('topic', res)
         self.assertEqual(len(res['topic']), len(res['theme']))
-        self.assertEqual(res['topic'][0]['tag'], "Physics: Optical physics")
-        self.assertEqual(res['theme'][0], "Physics: Optical physics")
+        self.assertEqual(res['topic'][0]['tag'], "Physics: Optical physics and communications")
+        self.assertEqual(res['theme'][0], "Physics: Optical physics and communications")
         
         cvtr.fix_themes = False
         res = cvtr.convert_data(data, "ark:ID")
         self.assertIn('topic', res)
         self.assertEqual(len(res['topic']), len(res['theme']))
-        self.assertEqual(res['topic'][0]['tag'], "Physics: Optical physics")
+        self.assertEqual(res['topic'][0]['tag'], "Physics: Optical physics and communications")
         self.assertEqual(res['theme'][0], "optical physics")
 
     def test_themes2topics(self):
@@ -109,7 +109,7 @@ class TestPODds2Res(unittest.TestCase):
         data['topic'] = cvtr.themes2topics(data['theme'])
         self.assertEqual(len(data['topic']), len(data['theme']))
         self.assertEqual(data['theme'][0], "Optical physics")
-        self.assertEqual(data['topic'][0]['tag'], "Physics: Optical physics")
+        self.assertEqual(data['topic'][0]['tag'], "Physics: Optical physics and communications")
         self.assertTrue(data['topic'][0].get('scheme').startswith("https://data.nist.gov/od/dm/nist-themes/"))
 
         self.assertEqual(data['topic'][1]['tag'], "Goober and the Peas")
@@ -135,7 +135,7 @@ class TestPODds2Res(unittest.TestCase):
         themes = cvtr.topics2themes(data['topic'])
 
         self.assertEqual(len(themes), len(data['topic']))
-        self.assertEqual(themes[0], "Physics: Optical physics")
+        self.assertEqual(themes[0], "Physics: Optical physics and communications")
         self.assertEqual(themes[1], "Goober and the Peas")
         self.assertEqual(themes[2], "Bioscience")
         self.assertEqual(themes[3], "Chemistry")
@@ -143,7 +143,7 @@ class TestPODds2Res(unittest.TestCase):
         themes = cvtr.topics2themes(data['topic'], False)
 
         self.assertEqual(len(themes), len(data['topic'])-1)
-        self.assertEqual(themes[0], "Physics: Optical physics")
+        self.assertEqual(themes[0], "Physics: Optical physics and communications")
         self.assertEqual(themes[1], "Bioscience")
         self.assertEqual(themes[2], "Chemistry")
 
@@ -151,7 +151,7 @@ class TestPODds2Res(unittest.TestCase):
         data['topic'][0]['scheme'] = re.sub('data', 'www', data['topic'][0]['scheme'])
         themes = cvt.topics2themes(data['topic'], False) # as a module function
         self.assertEqual(len(themes), len(data['topic'])-1)
-        self.assertEqual(themes[0], "Physics: Optical physics")
+        self.assertEqual(themes[0], "Physics: Optical physics and communications")
         
 
     def test_massage_themes(self):
@@ -168,7 +168,7 @@ class TestPODds2Res(unittest.TestCase):
         cvtr.massage_themes(data)
 
         self.assertEqual(len(data['theme']), len(data['topic']))
-        self.assertEqual(data['theme'][0], "Physics: Optical physics")
+        self.assertEqual(data['theme'][0], "Physics: Optical physics and communications")
         self.assertEqual(data['theme'][1], "Goober and the Peas")
         self.assertEqual(data['theme'][2], "Bioscience")
         self.assertEqual(data['theme'][3], "Chemistry")

--- a/python/tests/nistoar/nerdm/test_taxonomy.py
+++ b/python/tests/nistoar/nerdm/test_taxonomy.py
@@ -14,7 +14,7 @@ class TestResearchTopicsTaxonomy(unittest.TestCase):
         self.tax = taxon.ResearchTopicsTaxonomy.from_schema_dir(schemadir)
 
     def test_ctor(self):
-        self.assertEqual(self.tax.data['version'], "1.1")
+        self.assertEqual(self.tax.data['version'], "2.0")
         self.assertIsNotNone(self.tax.taillu)
         self.assertIsNotNone(self.tax.fulllu)
         self.assertIn('Bioscience', self.tax.taillu)
@@ -73,7 +73,7 @@ class TestResearchTopicsTaxonomy(unittest.TestCase):
         topics = self.tax.themes2topics(themes)
         
         self.assertEqual(len(topics), len(themes))
-        self.assertEqual(topics[0]['tag'], "Physics: Optical physics")
+        self.assertEqual(topics[0]['tag'], "Physics: Optical physics and communications")
         self.assertTrue(topics[0].get('scheme').startswith("https://data.nist.gov/od/dm/nist-themes/"))
 
         self.assertEqual(topics[1]['tag'], "Goober and the Peas")
@@ -89,7 +89,7 @@ class TestResearchTopicsTaxonomy(unittest.TestCase):
         term = self.tax.match_theme("Biomaterials", False)
         topic = term.as_topic()
         self.assertEqual(topic['@type'], "Concept")
-        self.assertEqual(topic['scheme'], "https://data.nist.gov/od/dm/nist-themes/v1.1")
+        self.assertEqual(topic['scheme'], "https://data.nist.gov/od/dm/nist-themes/v2.0")
         self.assertEqual(topic['tag'], "Bioscience: Biomaterials")
         
         

--- a/python/tests/nistoar/rmm/mongo/test_taxon.py
+++ b/python/tests/nistoar/rmm/mongo/test_taxon.py
@@ -233,13 +233,13 @@ class TestTaxonomyLoader(test.TestCase):
 
     def test_load_from_file(self):
         res = self.ldr.load_from_file(taxdatafile)
-        self.assertEqual(res.attempt_count, 249)
-        self.assertEqual(res.success_count, 249)
+        self.assertEqual(res.attempt_count, 277)
+        self.assertEqual(res.success_count, 277)
         self.assertEqual(res.failure_count, 0)
 
         key = {'term': "Advanced Communications", "parent": ""}
         self.assertTrue(res.succeeded(key))
-        self.assertEqual(self.ldr._client.get_database().taxonomy.count_documents({}), 249)
+        self.assertEqual(self.ldr._client.get_database().taxonomy.count_documents({}), 277)
         c = self.ldr._client.get_database().taxonomy.find(key)
         self.assertEqual(c[0]['level'], 1)
         

--- a/python/tests/nistoar/taxonomy/cache/test_files.py
+++ b/python/tests/nistoar/taxonomy/cache/test_files.py
@@ -71,7 +71,7 @@ class FilesTaxonomyCacheTest(test.TestCase):
         tax = cache.load_taxonomy(NIST_THEMES_URI_BASE+'v2.0')
         self.assertTrue(isinstance(tax, files.Taxonomy))
         self.assertEqual(tax.id, NIST_THEMES_URI_BASE+'v2.0')
-        self.assertTrue(tax.about_term('Bioscience'))
+        self.assertTrue(tax.match_label('Bioscience'))
 
     def test_export(self):
         cache = files.FileTaxonomyCache(taxdir, r"^theme-taxonomy.*")

--- a/python/tests/nistoar/taxonomy/cache/test_files.py
+++ b/python/tests/nistoar/taxonomy/cache/test_files.py
@@ -1,0 +1,226 @@
+import os, sys, pdb, json, time, logging, tempfile, shutil
+import unittest as test
+from pathlib import Path
+from typing import Mapping
+
+import yaml
+
+from nistoar.testing import *
+from nistoar.taxonomy.cache import files
+
+testdir = Path(__file__).parents[0]
+basedir = testdir.parents[4]
+taxdir = basedir / 'model'
+taxfile = taxdir / 'theme-taxonomy.json'
+
+loghdlr = None
+rootlog = None
+tmpdir  = None
+def setUpModule():
+    global loghdlr
+    global rootlog
+    global tmpdir
+    tmpdir = tempfile.TemporaryDirectory(prefix="_test_tax.")
+    rootlog = logging.getLogger()
+    rootlog.setLevel(logging.DEBUG)
+    loghdlr = logging.FileHandler(os.path.join(tmpdir.name,"test_tax.log"))
+    loghdlr.setLevel(logging.DEBUG)
+    loghdlr.setFormatter(logging.Formatter("%(levelname)s: %(name)s: %(message)s"))
+    rootlog.addHandler(loghdlr)
+
+def tearDownModule():
+    global loghdlr
+    global tmpdir
+    if loghdlr:
+        if rootlog:
+            rootlog.removeHandler(loghdlr)
+            loghdlr.flush()
+            loghdlr.close()
+        loghdlr = None
+    if tmpdir:
+        tmpdir.cleanup()
+
+NIST_THEMES_URI_BASE = "https://data.nist.gov/od/dm/nist-themes/"
+
+class FilesTaxonomyCacheTest(test.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_scan_load(self):
+        cache = files.FileTaxonomyCache(taxdir, r"^theme-taxonomy.*")
+        self.assertEqual(cache.count(), 3)
+        ids = list(cache.ids())
+        self.assertTrue(all(d.startswith(NIST_THEMES_URI_BASE) for d in ids))
+        self.assertIn(NIST_THEMES_URI_BASE+'v2.0', ids)
+        self.assertIn(NIST_THEMES_URI_BASE+'v1.1', ids)
+        self.assertIn(NIST_THEMES_URI_BASE+'p1.0', ids)
+
+        self.assertTrue(cache.is_known(NIST_THEMES_URI_BASE+'v2.0'))
+        self.assertTrue(cache.is_known(NIST_THEMES_URI_BASE+'v1.1'))
+        self.assertTrue(cache.is_known(NIST_THEMES_URI_BASE+'p1.0'))
+
+        info = cache.about(NIST_THEMES_URI_BASE+'v2.0')
+        self.assertTrue(isinstance(info, Mapping))
+        self.assertIn('location', info)
+        self.assertIn('id', info)
+        self.assertIn('title', info)
+        self.assertIn('version', info)
+        self.assertTrue(os.path.isfile(info['location']))
+
+        tax = cache.load_taxonomy(NIST_THEMES_URI_BASE+'v2.0')
+        self.assertTrue(isinstance(tax, files.Taxonomy))
+        self.assertEqual(tax.id, NIST_THEMES_URI_BASE+'v2.0')
+        self.assertTrue(tax.about_term('Bioscience'))
+
+    def test_export(self):
+        cache = files.FileTaxonomyCache(taxdir, r"^theme-taxonomy.*")
+
+        outf = Path(tmpdir.name) / "tl.json"
+        self.assertTrue(not outf.exists())
+        try:
+            cache.export_locations(outf)
+            self.assertTrue(outf.is_file())
+            with open(outf) as fd:
+                taxes = json.load(fd)
+
+            self.assertTrue(isinstance(taxes, Mapping))
+            self.assertNotIn('baseDirectory', taxes)
+            self.assertNotIn('pattern', taxes)
+            self.assertEqual(len(taxes.get('taxonomy')), 3)
+            locs = [Path(t['location']) for t in taxes['taxonomy']]
+
+            # destination dir is different from location of files, so paths are absolute
+            self.assertTrue(all(p.is_absolute() for p in locs))
+            self.assertTrue(all(p.is_file() for p in locs))
+
+        finally:
+            if outf.exists():
+                os.remove(outf)
+
+        outf = Path(tmpdir.name) / "taxonomyLocations.json"
+        self.assertTrue(not outf.exists())
+        try:
+            cache.export_locations(tmpdir.name, "json")
+            self.assertTrue(outf.is_file())
+            with open(outf) as fd:
+                taxes = json.load(fd)
+
+            self.assertTrue(isinstance(taxes, Mapping))
+            self.assertNotIn('baseDirectory', taxes)
+            self.assertNotIn('pattern', taxes)
+            self.assertEqual(len(taxes.get('taxonomy')), 3)
+            locs = [Path(t['location']) for t in taxes['taxonomy']]
+
+            # destination dir is different from location of files, so paths are absolute
+            self.assertTrue(all(p.is_absolute() for p in locs))
+            self.assertTrue(all(p.is_file() for p in locs))
+
+        finally:
+            if outf.exists():
+                os.remove(outf)
+
+        outf = Path(tmpdir.name) / "taxonomyLocations.yml"
+        self.assertTrue(not outf.exists())
+        try:
+            cache.export_locations(tmpdir.name)
+            self.assertTrue(outf.is_file())
+            with open(outf) as fd:
+                taxes = yaml.safe_load(fd)
+
+            self.assertTrue(isinstance(taxes, Mapping))
+            self.assertNotIn('baseDirectory', taxes)
+            self.assertNotIn('pattern', taxes)
+            self.assertEqual(len(taxes.get('taxonomy')), 3)
+            locs = [Path(t['location']) for t in taxes['taxonomy']]
+
+            # destination dir is different from location of files, so paths are absolute
+            self.assertTrue(all(p.is_absolute() for p in locs))
+            self.assertTrue(all(p.is_file() for p in locs))
+
+            # now try reloading cache from this file
+            cache = files.FileTaxonomyCache(outf)
+            self.assertEqual(cache.count(), 3)
+            id = list(cache.ids())[0]
+            tax = cache.load_taxonomy(id)
+
+        finally:
+            if outf.exists():
+                os.remove(outf)
+
+class MoreExportTest(test.TestCase):
+
+    def setUp(self):
+        self.taxdir = Path(tmpdir.name) / "taxons"
+        if self.taxdir.is_dir():
+            shutil.rmtree(self.taxdir)
+
+        os.mkdir(self.taxdir)
+        for f in os.listdir(taxdir):
+            if "-taxonomy" in f:
+                shutil.copy(taxdir/f, self.taxdir)
+
+    def tearDown(self):
+        if self.taxdir.is_dir():
+            shutil.rmtree(self.taxdir)
+
+    def test_baseDirectory(self):
+        cache = files.FileTaxonomyCache(self.taxdir, r"^.*-taxonomy.*\.json")
+        self.assertEqual(cache.count(), 6)
+
+        outf = self.taxdir/"taxonomyLocations.json"
+        self.assertTrue(not outf.exists())
+        cache.export_locations(self.taxdir, "json", True)
+        
+        self.assertTrue(outf.is_file())
+        with open(outf) as fd:
+            taxes = json.load(fd)
+        self.assertEqual(taxes.get('baseDirectory'), str(self.taxdir))
+        self.assertNotIn('pattern', taxes)
+        self.assertEqual(len(taxes.get('taxonomy')), 6)
+        locs = [Path(t['location']) for t in taxes['taxonomy']]
+
+        # destination dir is different from location of files, so paths are absolute
+        self.assertTrue(all(not p.is_absolute() for p in locs))
+        self.assertTrue(all((self.taxdir/p).is_file() for p in locs))
+
+        # now reread the locations file to load the 
+        cache = files.FileTaxonomyCache(outf)
+        self.assertEqual(cache.count(), 6)
+        id = list(cache.ids())[0]
+        tax = cache.load_taxonomy(id)
+
+
+    def test_implied_baseDirectory(self):
+        cache = files.FileTaxonomyCache(self.taxdir, r"^.*-taxonomy.*\.json")
+        self.assertEqual(cache.count(), 6)
+
+        outf = self.taxdir/"taxonomyLocations.yml"
+        self.assertTrue(not outf.exists())
+        cache.export_locations(self.taxdir)
+        
+        
+        self.assertTrue(outf.is_file())
+        with open(outf) as fd:
+            taxes = yaml.safe_load(fd)
+        self.assertNotIn('baseDirectory', taxes)
+        self.assertNotIn('pattern', taxes)
+        self.assertEqual(len(taxes.get('taxonomy')), 6)
+        locs = [Path(t['location']) for t in taxes['taxonomy']]
+
+        # destination dir is different from location of files, so paths are absolute
+        self.assertTrue(all(not p.is_absolute() for p in locs))
+        self.assertTrue(all((self.taxdir/p).is_file() for p in locs))
+
+        # now reread the locations file to load the 
+        cache = files.FileTaxonomyCache(outf)
+        self.assertEqual(cache.count(), 6)
+        id = list(cache.ids())[0]
+        tax = cache.load_taxonomy(id)
+
+    
+
+        
+
+if __name__ == '__main__':
+    test.main()

--- a/python/tests/nistoar/taxonomy/test_simple.py
+++ b/python/tests/nistoar/taxonomy/test_simple.py
@@ -9,7 +9,7 @@ from nistoar.taxonomy import simple
 testdir = Path(__file__).parents[0]
 basedir = testdir.parents[3]
 taxdir = basedir / 'model'
-ymlconf = basedir / 'docker' / 'ingestservice' / 'ingest_config.yml'
+ymlconf = basedir / 'docker' / 'mdtests' / 'ingest_conf.yml'
 taxfile = taxdir / 'theme-taxonomy.json'
 
 class TaxonomyTest(test.TestCase):

--- a/python/tests/nistoar/taxonomy/test_simple.py
+++ b/python/tests/nistoar/taxonomy/test_simple.py
@@ -58,7 +58,7 @@ class TaxonomyTest(test.TestCase):
     def test_get(self):
         tax = simple.SimpleTaxonomy.from_file(taxfile)
 
-        term = tax.about_term("Bioscience: Biomaterials")
+        term = tax.match_label("Bioscience: Biomaterials")
         self.assertTrue(isinstance(term, Mapping))
         self.assertEqual(term['label'], "Bioscience: Biomaterials")
         self.assertEqual(term['level'], 2)
@@ -73,7 +73,7 @@ class TaxonomyTest(test.TestCase):
         self.assertTrue(tax.equivalent(term, term2))
         self.assertTrue(tax.equivalent(term2, term))
 
-        term = tax.about_term("Bioscience")
+        term = tax.match_label("Bioscience")
         self.assertEqual(term['label'], "Bioscience")
         self.assertEqual(term['level'], 1)
         self.assertNotIn('parent', term)
@@ -88,9 +88,9 @@ class TaxonomyTest(test.TestCase):
         self.assertTrue(tax.is_narrower_than_or_equiv(term2, term))
         self.assertTrue(not tax.is_narrower_than_or_equiv(term, term2))
 
-        self.assertIsNotNone(tax.about_term("Materials"))
-        self.assertIsNotNone(tax.about_term("Materials: Materials characterization"))
-        term = tax.about_term("Materials: Materials characterization: Thermal properties")
+        self.assertIsNotNone(tax.match_label("Materials"))
+        self.assertIsNotNone(tax.match_label("Materials: Materials characterization"))
+        term = tax.match_label("Materials: Materials characterization: Thermal properties")
         self.assertIsNotNone(term)
         self.assertEqual(term['label'],
                          "Materials: Materials characterization: Thermal properties")
@@ -108,8 +108,8 @@ class TaxonomyTest(test.TestCase):
         self.assertTrue(not tax.is_narrower_than_or_equiv(term2, term))
         self.assertTrue(not tax.is_narrower_than_or_equiv(term, term2))
         
-        self.assertIsNone(tax.about_term("Health: Cancer"))
-        self.assertIsNone(tax.about_term("Cancer"))
+        self.assertIsNone(tax.match_label("Health: Cancer"))
+        self.assertIsNone(tax.match_label("Cancer"))
 
     def test_iter(self):
         tax = simple.SimpleTaxonomy.from_file(taxfile)
@@ -119,7 +119,7 @@ class TaxonomyTest(test.TestCase):
         self.assertTrue(all('term' in t for t in tax.terms()))
         self.assertTrue(all('level' in t for t in tax.terms()))
         self.assertEqual(len(list(tax.terms())), tax.count())
-        mat = tax.about_term("Materials")
+        mat = tax.match_label("Materials")
         matly = [t for t in tax.terms() if tax.is_narrower_than_or_equiv(t, mat)]
         self.assertTrue(all(t['label'].startswith('Materials') for t in matly))
         self.assertEqual(  len([t for t in matly if t['level'] == 1]), 1)

--- a/python/tests/nistoar/taxonomy/test_simple.py
+++ b/python/tests/nistoar/taxonomy/test_simple.py
@@ -1,0 +1,143 @@
+import os, sys, pdb, json, time, logging
+import unittest as test
+from pathlib import Path
+from typing import Mapping
+
+from nistoar.testing import *
+from nistoar.taxonomy import simple
+
+testdir = Path(__file__).parents[0]
+basedir = testdir.parents[3]
+taxdir = basedir / 'model'
+ymlconf = basedir / 'docker' / 'ingestservice' / 'ingest_config.yml'
+taxfile = taxdir / 'theme-taxonomy.json'
+
+class TaxonomyTest(test.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_load_file(self):
+        data = simple._load_file(ymlconf)
+        self.assertIn('logfile', data)
+
+        data = simple._load_file(taxfile)
+        self.assertIn('@id', data)
+
+        try:
+            data = simple._load_file("goober.txt", "goober")
+            self.fail("Failed to raise on missing file")
+        except IOError as ex:
+            self.assertIn("goober file", str(ex))
+
+        try:
+            data = simple._load_file(basedir/'LICENSE.md')
+            self.fail("Failed to raise on missing file")
+        except IOError as ex:
+            self.assertIn("unsupported", str(ex))
+
+    def test_from_file(self):
+        uri = simple._load_file(taxfile)['@id']
+        
+        tax = simple.SimpleTaxonomy.from_file(taxfile)
+        self.assertEqual(tax.id, uri)
+        about = tax.about()
+        self.assertIn('title', about)
+        self.assertIn('schema', about)
+        self.assertIn('description', about)
+        self.assertNotIn('vocab', about)
+
+        title = about['title']
+        about['title'] = "Hacked!"
+        about = tax.about()
+        self.assertEqual(about['title'], title)
+
+        self.assertGreater(tax.count(), 100)
+#        self.assertEqual(tax.count(), 277)   #this number will change as taxon evolves
+        
+    def test_get(self):
+        tax = simple.SimpleTaxonomy.from_file(taxfile)
+
+        term = tax.about_term("Bioscience: Biomaterials")
+        self.assertTrue(isinstance(term, Mapping))
+        self.assertEqual(term['label'], "Bioscience: Biomaterials")
+        self.assertEqual(term['level'], 2)
+        self.assertEqual(term['parent'], "Bioscience")
+        self.assertEqual(term['id'], tax.id+'#Bioscience%3A%20Biomaterials')
+
+        term2 = tax.get(term['id'])
+        self.assertTrue(isinstance(term2, Mapping))
+        self.assertEqual(term2['label'], "Bioscience: Biomaterials")
+        self.assertEqual(term2['id'], tax.id+'#Bioscience%3A%20Biomaterials')
+        self.assertEqual(tax.compare_meaning(term, term2), 0)
+        self.assertTrue(tax.equivalent(term, term2))
+        self.assertTrue(tax.equivalent(term2, term))
+
+        term = tax.about_term("Bioscience")
+        self.assertEqual(term['label'], "Bioscience")
+        self.assertEqual(term['level'], 1)
+        self.assertNotIn('parent', term)
+        self.assertEqual(term['id'], tax.id+'#Bioscience')
+        
+        self.assertTrue(not tax.equivalent(term, term2))
+        self.assertTrue(not tax.equivalent(term2, term))
+        self.assertEqual(tax.compare_meaning(term, term2), -1)
+        self.assertEqual(tax.compare_meaning(term2, term),  1)
+        self.assertTrue(tax.is_broader_than(term, term2))
+        self.assertTrue(not tax.is_broader_than(term2, term))
+        self.assertTrue(tax.is_narrower_than_or_equiv(term2, term))
+        self.assertTrue(not tax.is_narrower_than_or_equiv(term, term2))
+
+        self.assertIsNotNone(tax.about_term("Materials"))
+        self.assertIsNotNone(tax.about_term("Materials: Materials characterization"))
+        term = tax.about_term("Materials: Materials characterization: Thermal properties")
+        self.assertIsNotNone(term)
+        self.assertEqual(term['label'],
+                         "Materials: Materials characterization: Thermal properties")
+        self.assertEqual(term['level'], 3)
+        self.assertEqual(term['parent'], "Materials: Materials characterization")
+        self.assertEqual(term['id'],
+                tax.id+'#Materials%3A%20Materials%20characterization%3A%20Thermal%20properties')
+
+        self.assertIsNone(tax.compare_meaning(term, term2))
+        self.assertIsNone(tax.compare_meaning(term2, term))
+        self.assertTrue(not tax.equivalent(term, term2))
+        self.assertTrue(not tax.equivalent(term2, term))
+        self.assertTrue(not tax.is_broader_than(term, term2))
+        self.assertTrue(not tax.is_broader_than(term2, term))
+        self.assertTrue(not tax.is_narrower_than_or_equiv(term2, term))
+        self.assertTrue(not tax.is_narrower_than_or_equiv(term, term2))
+        
+        self.assertIsNone(tax.about_term("Health: Cancer"))
+        self.assertIsNone(tax.about_term("Cancer"))
+
+    def test_iter(self):
+        tax = simple.SimpleTaxonomy.from_file(taxfile)
+
+        self.assertTrue(all('label' in t for t in tax.terms()))
+        self.assertTrue(all('id' in t for t in tax.terms()))
+        self.assertTrue(all('term' in t for t in tax.terms()))
+        self.assertTrue(all('level' in t for t in tax.terms()))
+        self.assertEqual(len(list(tax.terms())), tax.count())
+        mat = tax.about_term("Materials")
+        matly = [t for t in tax.terms() if tax.is_narrower_than_or_equiv(t, mat)]
+        self.assertTrue(all(t['label'].startswith('Materials') for t in matly))
+        self.assertEqual(  len([t for t in matly if t['level'] == 1]), 1)
+        self.assertGreater(len([t for t in matly if t['level'] == 2]), 1)
+        self.assertGreater(len([t for t in matly if t['level'] == 3]), 1)
+        self.assertEqual(  len([t for t in matly if t['level']  > 3]), 0)
+#        self.assertEqual(len(matly), 12)   #this number will change as taxon evolves
+
+    def test_summary_from(self):
+        content = simple._load_file(taxfile)
+        data = simple.SimpleTaxonomy._summary_from(content)
+        self.assertNotIn('vocab', data)
+        self.assertNotIn('_schema', data)
+        self.assertNotIn('@id', data)
+        self.assertTrue(data.get('id'))
+        self.assertTrue(data.get('schema'))
+        
+        
+
+if __name__ == '__main__':
+    test.main()

--- a/scripts/install_extras.sh
+++ b/scripts/install_extras.sh
@@ -15,7 +15,11 @@ mkdir -p $SCHEMA_DIR
 schemafiles=`ls -d $SOURCE_DIR/model/*.json{,ld} | grep -v nerdm-fields-help`
 echo cp $schemafiles $SCHEMA_DIR
 cp $schemafiles $SCHEMA_DIR
-echo
+tlocs="$SOURCE_DIR/model/taxonomyLocations-by-patt.yml"
+if [ -f "$tlocs" ]; then
+    cp $tlocs $SCHEMA_DIR
+    SCHEMA_DIR=$SCHEMA_DIR $execdir/install_taxlocfile.py
+fi
 
 # install the jq modules
 mkdir -p $JQ_LIBDIR

--- a/scripts/install_extras.sh
+++ b/scripts/install_extras.sh
@@ -18,7 +18,7 @@ cp $schemafiles $SCHEMA_DIR
 tlocs="$SOURCE_DIR/model/taxonomyLocations-by-patt.yml"
 if [ -f "$tlocs" ]; then
     cp $tlocs $SCHEMA_DIR
-    SCHEMA_DIR=$SCHEMA_DIR $execdir/install_taxlocfile.py
+    SCHEMA_DIR=$SCHEMA_DIR PYTHONPATH=$PY_LIBDIR $execdir/install_taxlocfile.py
 fi
 
 # install the jq modules

--- a/scripts/install_taxlocfile.py
+++ b/scripts/install_taxlocfile.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+#
+import os
+from pathlib import Path
+import nistoar.taxonomy as tax
+schemadir = os.environ.get('SCHEMA_DIR')
+if schemadir:
+    schemadir = Path(schemadir)
+cache = tax.FileTaxonomyCache(schemadir/'taxonomyLocations-by-patt.yml')
+print(f"Registering {cache.count()} taxonomies")
+cache.export_locations(schemadir)


### PR DESCRIPTION
This PR adds the `nistoar.taxonomy` module to support multiple taxonomies as well as multiple versions of taxonomies.  It provides the facility to discover and load all taxonomies known to the system.  It was motivated by the need to not only support different collection taxonomies used as topics in NERDm records.  MIDAS in particular needs to validate that a topic term is a legal term in a recognized taxonomy.  

This module deprecates `nistoar.nerdm.taxonomy`, but replacement is not yet complete.  This older module is still used in `nistoar.nerdm.convert.pod` (which also needs to be deprecated).
