### PR TITLE
Fix runtime errors in the deprecated SimpleTaxonomy term path

### DIFF
--- a/python/nistoar/taxonomy/simple.py
+++ b/python/nistoar/taxonomy/simple.py
@@ -87,15 +87,15 @@ class SimpleTaxonomy(Taxonomy):
             if not term.get('label'):
                 term['label'] = labelfor(term)
 
+            frag = label2idfrag(term['label'])
             if not term.get('id'):
-                frag = label2idfrag(term['label'])
                 term['id'] = self.id + frag
 
             if term.get('deprecatedSince'):
                 # this is a deprecated term
                 if incl_depr and term.get('lastSupported'):
                     # include it, but make sure we get the ID right
-                    term['id'] = f"{idsansver}/v{term['lastSupported']}{term.get['id']}"
+                    term['id'] = f"{idsansver}/v{term['lastSupported']}{term.get('id', '')}"
                 else:
                     # skipping deprecated terms
                     continue

--- a/python/tests/nistoar/taxonomy/test_simple.py
+++ b/python/tests/nistoar/taxonomy/test_simple.py
@@ -136,6 +136,75 @@ class TaxonomyTest(test.TestCase):
         self.assertNotIn('@id', data)
         self.assertTrue(data.get('id'))
         self.assertTrue(data.get('schema'))
+
+    def make_content(self):
+        # a minimal taxonomy that exercises the deprecated-term branch.  The
+        # shipped model files do not carry lastSupported or pre-set term ids, so
+        # this path was never covered by the other tests.
+        return {
+            "@id": "https://example.gov/taxon/v2.0",
+            "_schema": simple.SimpleTaxonomy.SCHEMA_URI,
+            "title": "Test taxonomy",
+            "vocab": [
+                { "term": "Physics", "level": 1 },
+                { "parent": "Physics", "term": "Optics", "level": 2 },
+                # a term that already carries an explicit id (the loop must not
+                # assume it has to mint one)
+                { "parent": "Physics", "term": "Acoustics", "level": 2,
+                  "id": "https://example.gov/taxon/v2.0#Physics%3A%20Acoustics" },
+                # deprecated but still supported under an earlier version
+                { "parent": "Physics", "term": "Old optics", "level": 2,
+                  "deprecatedSince": "2.0", "lastSupported": "1.1" },
+                # deprecated with no lastSupported -> should be dropped
+                { "parent": "Physics", "term": "Gone", "level": 2,
+                  "deprecatedSince": "2.0" },
+            ]
+        }
+
+    def test_include_deprecated(self):
+        tax = simple.SimpleTaxonomy._from_content(self.make_content(), incl_depr=True)
+
+        # the live and deprecated-but-supported terms are present; the fully
+        # dropped one is not
+        self.assertIsNotNone(tax.match_label("Physics"))
+        self.assertIsNotNone(tax.match_label("Physics: Optics"))
+        self.assertIsNotNone(tax.match_label("Physics: Acoustics"))
+        self.assertIsNone(tax.match_label("Physics: Gone"))
+
+        depr = tax.match_label("Physics: Old optics")
+        self.assertIsNotNone(depr)
+        # the deprecated term keeps the version it was last supported in
+        self.assertIn("/v1.1", depr['id'])
+        self.assertEqual(tax.count(), 4)
+
+    def test_exclude_deprecated(self):
+        tax = simple.SimpleTaxonomy._from_content(self.make_content())  # incl_depr defaults to False
+
+        self.assertIsNotNone(tax.match_label("Physics"))
+        self.assertIsNotNone(tax.match_label("Physics: Optics"))
+        self.assertIsNotNone(tax.match_label("Physics: Acoustics"))
+        self.assertIsNone(tax.match_label("Physics: Old optics"))
+        self.assertIsNone(tax.match_label("Physics: Gone"))
+        self.assertEqual(tax.count(), 3)
+
+    def test_term_with_preset_id_first(self):
+        # if the very first vocab term already carries an id, the loop must not
+        # rely on an id-fragment computed by an earlier iteration
+        content = {
+            "@id": "https://example.gov/taxon/v2.0",
+            "_schema": simple.SimpleTaxonomy.SCHEMA_URI,
+            "title": "Test taxonomy",
+            "vocab": [
+                { "term": "Acoustics", "level": 1,
+                  "id": "https://example.gov/taxon/v2.0#Acoustics" },
+            ]
+        }
+        tax = simple.SimpleTaxonomy._from_content(content)
+        self.assertEqual(tax.count(), 1)
+        term = tax.match_label("Acoustics")
+        self.assertIsNotNone(term)
+        self.assertEqual(term['id'], "https://example.gov/taxon/v2.0#Acoustics")
+        self.assertIsNotNone(tax.get(term['id']))
         
         
 


### PR DESCRIPTION
Two bugs in `nistoar/taxonomy/simple.py` that crash `SimpleTaxonomy` once the deprecated-term branch runs (e.g. loading with `incl_depr=True`). The shipped model files don't set `lastSupported` or pre-assigned term ids, so this path isn't exercised by the current tests, which is how it slipped through.

First, the line that re-stamps a deprecated term's id has `term.get['id']`, which subscripts the bound `get` method instead of calling it and throws `TypeError: 'builtin_function_or_method' object is not subscriptable`. Changed it to `term.get('id', '')`.

Second, `frag` (the key into `self._byid`) was only assigned inside the `if not term.get('id')` block. A term that already has an id reaches `self._byid[frag]` with `frag` unbound (`UnboundLocalError`) or holding a stale value from the previous iteration, which files the term under the wrong key and drops it from `count()`. I moved the `frag = label2idfrag(term['label'])` assignment outside the conditional so it's always computed; the id is still only minted when missing.

Added tests covering a deprecated-but-supported term, a deprecated term with no `lastSupported`, a term with its own id, and a first vocab entry that already has an id. They fail on the current code and pass with the fix; the rest of `tests/nistoar/taxonomy/` stays green.

Refs #70.